### PR TITLE
Add CCPA query param

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -42,6 +42,10 @@ export const tripleliftAdapterSpec = {
       }
     }
 
+    if (bidderRequest && bidderRequest.uspConsent) {
+      tlCall = utils.tryAppendQueryString(tlCall, 'us_privacy', bidderRequest.uspConsent);
+    }
+
     if (tlCall.lastIndexOf('&') === tlCall.length - 1) {
       tlCall = tlCall.substring(0, tlCall.length - 1);
     }
@@ -62,7 +66,7 @@ export const tripleliftAdapterSpec = {
     });
   },
 
-  getUserSyncs: function(syncOptions) {
+  getUserSyncs: function(syncOptions, responses, gdprConsent, usPrivacy) {
     let syncType = _getSyncType(syncOptions);
     if (!syncType) return;
 
@@ -76,6 +80,10 @@ export const tripleliftAdapterSpec = {
     if (consentString !== null) {
       syncEndpoint = utils.tryAppendQueryString(syncEndpoint, 'gdpr', gdprApplies);
       syncEndpoint = utils.tryAppendQueryString(syncEndpoint, 'cmp_cs', consentString);
+    }
+
+    if (typeof usPrivacy === 'string' && usPrivacy.length > 0) {
+      syncEndpoint = utils.tryAppendQueryString(syncEndpoint, 'us_privacy', usPrivacy);
     }
 
     return [{

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -82,7 +82,7 @@ export const tripleliftAdapterSpec = {
       syncEndpoint = utils.tryAppendQueryString(syncEndpoint, 'cmp_cs', consentString);
     }
 
-    if (typeof usPrivacy === 'string' && usPrivacy.length > 0) {
+    if (usPrivacy) {
       syncEndpoint = utils.tryAppendQueryString(syncEndpoint, 'us_privacy', usPrivacy);
     }
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -236,6 +236,12 @@ describe('triplelift adapter', function () {
       expect(url).to.match(new RegExp('(?:' + prebid.version + ')'))
       expect(url).to.match(/(?:referrer)/);
     });
+    it('should return us_privacy param when CCPA info is available', function() {
+      bidderRequest.uspConsent = '1YYY';
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const url = request.url;
+      expect(url).to.match(/(\?|&)us_privacy=1YYY/);
+    });
     it('should return schain when present', function() {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
@@ -400,6 +406,13 @@ describe('triplelift adapter', function () {
       let result = tripleliftAdapterSpec.getUserSyncs(syncOptions);
       expect(result[0].type).to.equal('iframe');
       expect(result[0].url).to.equal(expectedIframeSyncUrl);
+    });
+    it('sends us_privacy param when info is available', function() {
+      let syncOptions = {
+        iframeEnabled: true
+      };
+      let result = tripleliftAdapterSpec.getUserSyncs(syncOptions, null, null, '1YYY');
+      expect(result[0].url).to.match(/(\?|&)us_privacy=1YYY/);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Sends CCPA info as `us_privacy` query param to TLX auction API and sync endpoint.