### PR TITLE
Triplelift: FPD key value pair support

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -107,6 +107,8 @@ function _getSyncType(syncOptions) {
 function _buildPostBody(bidRequests) {
   let data = {};
   let { schain } = bidRequests[0];
+  const globalFpd = _getFilteredGlobalFpd();
+
   data.imp = bidRequests.map(function(bidRequest, index) {
     let imp = {
       id: index,
@@ -138,6 +140,16 @@ function _buildPostBody(bidRequests) {
       schain
     }
   }
+
+  if (!utils.isEmpty(globalFpd)) {
+    if (data.ext) {
+      data.ext.fpd = globalFpd;
+    } else {
+      data.ext = {
+        fpd: globalFpd,
+      }
+    }
+  }
   return data;
 }
 
@@ -166,6 +178,29 @@ function _getFloor (bid) {
     }
   }
   return floor !== null ? floor : bid.params.floor;
+}
+
+function _getFilteredGlobalFpd() {
+  let data = {};
+  const tlKeys = ['sens', 'category', 'pmp_elig'] // keys wanted in ext
+  let tlData = {};
+
+  const fpd = config.getConfig('fpd');
+
+  if (!utils.isEmpty(fpd)) {
+    if (fpd.context && fpd.context.data) {
+      data = { ...fpd.context.data };
+    }
+    if (fpd.user && fpd.user.data) {
+      data = { ...data, ...fpd.user.data };
+    }
+    tlKeys.forEach(key => {
+      if (data[key]) {
+        tlData[key] = data[key];
+      }
+    });
+  }
+  return tlData;
 }
 
 function getUnifiedIdEids(bidRequests) {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -389,21 +389,17 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
-    it('should send fpd on root level ext if specified kvps are available', function() {
-      const sens = ['alc', 'pol'];
+    it('should send fpd on root level ext if kvps are available', function() {
+      const sens = null;
       const category = ['news', 'weather', 'hurricane'];
       const pmp_elig = 'true';
       const fpd = {
         context: {
-          data: {
-            pmp_elig,
-            category,
-          }
+          pmp_elig,
+          category,
         },
         user: {
-          data: {
-            sens,
-          }
+          sens,
         }
       }
       sandbox.stub(config, 'getConfig').callsFake(key => {
@@ -414,34 +410,9 @@ describe('triplelift adapter', function () {
       });
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
-      expect(payload.ext.fpd).to.haveOwnProperty('sens');
+      expect(payload.ext.fpd).to.not.haveOwnProperty('sens');
       expect(payload.ext.fpd).to.haveOwnProperty('category');
       expect(payload.ext.fpd).to.haveOwnProperty('pmp_elig');
-    });
-    it('should not send fpd on root level ext if kvps are not available', function() {
-      const oneKey = 'one';
-      const twoKey = 'two';
-      const fpd = {
-        context: {
-          data: {
-            oneKey,
-          }
-        },
-        user: {
-          data: {
-            twoKey,
-          }
-        }
-      }
-      sandbox.stub(config, 'getConfig').callsFake(key => {
-        const config = {
-          fpd
-        };
-        return utils.deepAccess(config, key);
-      });
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
-      const { data: payload } = request;
-      expect(payload.ext.fpd).to.deep.equal(undefined);
     });
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { newBidder } from 'src/adapters/bidderFactory.js';
 import { deepClone } from 'src/utils.js';
 import { config } from 'src/config.js';
 import prebid from '../../../package.json';
+import * as utils from 'src/utils.js';
 
 const ENDPOINT = 'https://tlx.3lift.com/header/auction?';
 const GDPR_CONSENT_STR = 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7Vf7nnG072lPVA9LTOQ6gEaY';
@@ -11,6 +12,7 @@ const GDPR_CONSENT_STR = 'BOONm0NOONm0NABABAENAa-AAAARh7______b9_3__7_9uz_Kv_K7V
 describe('triplelift adapter', function () {
   const adapter = newBidder(tripleliftAdapterSpec);
   let bid, instreamBid;
+  let sandbox;
 
   this.beforeEach(() => {
     bid = {
@@ -194,6 +196,10 @@ describe('triplelift adapter', function () {
           gdprApplies: true
         },
       };
+      sandbox = sinon.sandbox.create();
+    });
+    afterEach(() => {
+      sandbox.restore();
     });
 
     it('exists and is an object', function () {
@@ -382,6 +388,60 @@ describe('triplelift adapter', function () {
       bidRequests[0].getFloor = () => floorInfo;
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
+    });
+    it('should send fpd on root level ext if specified kvps are available', function() {
+      const sens = ['alc', 'pol'];
+      const category = ['news', 'weather', 'hurricane'];
+      const pmp_elig = 'true';
+      const fpd = {
+        context: {
+          data: {
+            pmp_elig,
+            category,
+          }
+        },
+        user: {
+          data: {
+            sens,
+          }
+        }
+      }
+      sandbox.stub(config, 'getConfig').callsFake(key => {
+        const config = {
+          fpd
+        };
+        return utils.deepAccess(config, key);
+      });
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const { data: payload } = request;
+      expect(payload.ext.fpd).to.haveOwnProperty('sens');
+      expect(payload.ext.fpd).to.haveOwnProperty('category');
+      expect(payload.ext.fpd).to.haveOwnProperty('pmp_elig');
+    });
+    it('should not send fpd on root level ext if kvps are not available', function() {
+      const oneKey = 'one';
+      const twoKey = 'two';
+      const fpd = {
+        context: {
+          data: {
+            oneKey,
+          }
+        },
+        user: {
+          data: {
+            twoKey,
+          }
+        }
+      }
+      sandbox.stub(config, 'getConfig').callsFake(key => {
+        const config = {
+          fpd
+        };
+        return utils.deepAccess(config, key);
+      });
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      const { data: payload } = request;
+      expect(payload.ext.fpd).to.deep.equal(undefined);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
Resolves: https://triplelift.atlassian.net/browse/TL-17557
Adds global first party data to `ext`.
<img width="767" alt="Screen Shot 2020-09-10 at 11 17 15 AM" src="https://user-images.githubusercontent.com/50499465/92755978-5f516f00-f35a-11ea-9d18-fff0c6018a5e.png">

Ad unit `fpd` is already being in the `bidderRequest` and will stay on the ad unit level.
<img width="1154" alt="Screen Shot 2020-09-10 at 11 44 36 AM" src="https://user-images.githubusercontent.com/50499465/92757067-64fb8480-f35b-11ea-9905-0e4bbf00d5ee.png">


