### PR TITLE
adds coppa support back in

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -51,6 +51,10 @@ export const tripleliftAdapterSpec = {
       tlCall = utils.tryAppendQueryString(tlCall, 'us_privacy', bidderRequest.uspConsent);
     }
 
+    if (config.getConfig('coppa') === true) {
+      tlCall = utils.tryAppendQueryString(tlCall, 'coppa', true);
+    }
+
     if (tlCall.lastIndexOf('&') === tlCall.length - 1) {
       tlCall = tlCall.substring(0, tlCall.length - 1);
     }

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -369,6 +369,20 @@ describe('triplelift adapter', function () {
       const url = request.url;
       expect(url).to.match(/(\?|&)us_privacy=1YYY/);
     });
+    it('should return coppa param when COPPA config is set to true', function() {
+      sinon.stub(config, 'getConfig').withArgs('coppa').returns(true);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      config.getConfig.restore();
+      const url = request.url;
+      expect(url).to.match(/(\?|&)coppa=true/);
+    });
+    it('should not return coppa param when COPPA config is set to false', function() {
+      sinon.stub(config, 'getConfig').withArgs('coppa').returns(false);
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      config.getConfig.restore();
+      const url = request.url;
+      expect(url).not.to.match(/(\?|&)coppa=/);
+    });
     it('should return schain when present', function() {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;


### PR DESCRIPTION
`COPPA` work from this PR prebid#4850 was not showing up in triplelift-internal/master but is in the prebid repo https://github.com/prebid/Prebid.js/blob/466b49e85a1e173de255ef31c61a73f0cc4d8c57/modules/tripleliftBidAdapter.js#L54