### PR TITLE
TL-18466: add GVLid, update multiimp validation, add unit tests

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -3,20 +3,17 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
+const GVLID = 28;
 const BIDDER_CODE = 'triplelift';
 const STR_ENDPOINT = 'https://tlx.3lift.com/header/auction?';
 let gdprApplies = true;
 let consentString = null;
 
 export const tripleliftAdapterSpec = {
-
+  gvlid: GVLID,
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function (bid) {
-    if (bid.mediaTypes.video) {
-      let video = _getORTBVideo(bid);
-      if (!video.w || !video.h) return false;
-    }
     return typeof bid.params.inventoryCode !== 'undefined';
   },
 
@@ -295,6 +292,7 @@ function _buildResponseObject(bidderRequest, bid) {
 
     if (bid.advertiser_name) {
       bidResponse.meta.advertiserName = bid.advertiser_name;
+      bidResponse.meta.advertiserDomains = [bid.advertiser_name];
     }
   };
   return bidResponse;

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -292,7 +292,6 @@ function _buildResponseObject(bidderRequest, bid) {
 
     if (bid.advertiser_name) {
       bidResponse.meta.advertiserName = bid.advertiser_name;
-      bidResponse.meta.advertiserDomains = [bid.advertiser_name];
     }
   };
   return bidResponse;

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -748,14 +748,6 @@ describe('triplelift adapter', function () {
       expect(result[1].meta).to.not.have.key('advertiserName');
     });
 
-    it('should include the advertiser domain in the meta field if available', function () {
-      let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
-      expect(result[0].meta.advertiserDomains[0]).to.equal('fake advertiser name');
-      expect(result[0].meta.advertiserDomains.length).to.equal(1);
-      expect(result[1].meta).to.not.have.key('advertiserDomains');
-    });
-  });
-
   describe('getUserSyncs', function() {
     let expectedIframeSyncUrl = 'https://eb2.3lift.com/sync?gdpr=true&cmp_cs=' + GDPR_CONSENT_STR + '&';
     let expectedImageSyncUrl = 'https://eb2.3lift.com/sync?px=1&src=prebid&gdpr=true&cmp_cs=' + GDPR_CONSENT_STR + '&';

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -83,15 +83,21 @@ describe('triplelift adapter', function () {
       expect(tripleliftAdapterSpec.isBidRequestValid(instreamBid)).to.equal(true);
     });
 
+    it('should return true when required params found - instream - 2', function () {
+      delete instreamBid.mediaTypes.playerSize;
+      delete instreamBid.params.video.w;
+      delete instreamBid.params.video.h;
+      // the only required param is inventoryCode
+      expect(tripleliftAdapterSpec.isBidRequestValid(instreamBid)).to.equal(true);
+    });
+
     it('should return false when required params are not passed', function () {
       delete bid.params.inventoryCode;
       expect(tripleliftAdapterSpec.isBidRequestValid(bid)).to.equal(false);
     });
 
     it('should return false when required params are not passed - instream', function () {
-      delete instreamBid.mediaTypes.playerSize;
-      delete instreamBid.params.video.w;
-      delete instreamBid.params.video.h;
+      delete instreamBid.params.inventoryCode;
       expect(tripleliftAdapterSpec.isBidRequestValid(instreamBid)).to.equal(false);
     });
   });
@@ -165,6 +171,7 @@ describe('triplelift adapter', function () {
           userId: {},
           schain,
         },
+        // banner and outstream video
         {
           bidder: 'triplelift',
           params: {
@@ -188,6 +195,140 @@ describe('triplelift adapter', function () {
                 [970, 250],
                 [1, 1]
               ]
+            }
+          },
+          adUnitCode: 'adunit-code-instream',
+          sizes: [[300, 250], [300, 600], [1, 1, 1], ['flex']],
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          userId: {},
+          schain,
+        },
+        // banner and incomplete video
+        {
+          bidder: 'triplelift',
+          params: {
+            inventoryCode: 'outstream_test',
+            floor: 1.0,
+            video: {
+              mimes: ['video/mp4'],
+              maxduration: 30,
+              minduration: 6,
+              w: 640,
+              h: 480
+            }
+          },
+          mediaTypes: {
+            video: {
+
+            },
+            banner: {
+              sizes: [
+                [970, 250],
+                [1, 1]
+              ]
+            }
+          },
+          adUnitCode: 'adunit-code-instream',
+          sizes: [[300, 250], [300, 600], [1, 1, 1], ['flex']],
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          userId: {},
+          schain,
+        },
+        // incomplete banner and incomplete video
+        {
+          bidder: 'triplelift',
+          params: {
+            inventoryCode: 'outstream_test',
+            floor: 1.0,
+            video: {
+              mimes: ['video/mp4'],
+              maxduration: 30,
+              minduration: 6,
+              w: 640,
+              h: 480
+            }
+          },
+          mediaTypes: {
+            video: {
+
+            },
+            banner: {
+
+            }
+          },
+          adUnitCode: 'adunit-code-instream',
+          sizes: [[300, 250], [300, 600], [1, 1, 1], ['flex']],
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          userId: {},
+          schain,
+        },
+        // banner and instream video
+        {
+          bidder: 'triplelift',
+          params: {
+            inventoryCode: 'outstream_test',
+            floor: 1.0,
+            video: {
+              mimes: ['video/mp4'],
+              maxduration: 30,
+              minduration: 6,
+              w: 640,
+              h: 480
+            }
+          },
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              playerSize: [640, 480]
+            },
+            banner: {
+              sizes: [
+                [970, 250],
+                [1, 1]
+              ]
+            }
+          },
+          adUnitCode: 'adunit-code-instream',
+          sizes: [[300, 250], [300, 600], [1, 1, 1], ['flex']],
+          bidId: '30b31c1838de1e',
+          bidderRequestId: '22edbae2733bf6',
+          auctionId: '1d1a030790a475',
+          userId: {},
+          schain,
+        },
+        // banner and outream video and native
+        {
+          bidder: 'triplelift',
+          params: {
+            inventoryCode: 'outstream_test',
+            floor: 1.0,
+            video: {
+              mimes: ['video/mp4'],
+              maxduration: 30,
+              minduration: 6,
+              w: 640,
+              h: 480
+            }
+          },
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [640, 480]
+            },
+            banner: {
+              sizes: [
+                [970, 250],
+                [1, 1]
+              ]
+            },
+            native: {
+
             }
           },
           adUnitCode: 'adunit-code-instream',
@@ -261,10 +402,26 @@ describe('triplelift adapter', function () {
       expect(payload.imp[1].tagid).to.equal('insteam_test');
       expect(payload.imp[1].floor).to.equal(1.0);
       expect(payload.imp[1].video).to.exist.and.to.be.a('object');
-
+      // banner and outstream video
       expect(payload.imp[2]).to.not.have.property('video');
       expect(payload.imp[2]).to.have.property('banner');
       expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
+      // banner and incomplete video
+      expect(payload.imp[3]).to.not.have.property('video');
+      expect(payload.imp[3]).to.have.property('banner');
+      expect(payload.imp[3].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
+      // incomplete mediatypes.banner and incomplete video
+      expect(payload.imp[4]).to.not.have.property('video');
+      expect(payload.imp[4]).to.have.property('banner');
+      expect(payload.imp[4].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
+      // banner and instream video
+      expect(payload.imp[5]).to.not.have.property('banner');
+      expect(payload.imp[5]).to.have.property('video');
+      expect(payload.imp[5].video).to.exist.and.to.be.a('object');
+      // banner and outream video and native
+      expect(payload.imp[6]).to.not.have.property('video');
+      expect(payload.imp[6]).to.have.property('banner');
+      expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
     it('should add tdid to the payload if included', function () {
@@ -587,8 +744,15 @@ describe('triplelift adapter', function () {
 
     it('should include the advertiser name in the meta field if available', function () {
       let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
-      expect(result[0].meta.advertiserName).to.equal('fake advertiser name')
+      expect(result[0].meta.advertiserName).to.equal('fake advertiser name');
       expect(result[1].meta).to.not.have.key('advertiserName');
+    });
+
+    it('should include the advertiser domain in the meta field if available', function () {
+      let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
+      expect(result[0].meta.advertiserDomains[0]).to.equal('fake advertiser name');
+      expect(result[0].meta.advertiserDomains.length).to.equal(1);
+      expect(result[1].meta).to.not.have.key('advertiserDomains');
     });
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -747,6 +747,7 @@ describe('triplelift adapter', function () {
       expect(result[0].meta.advertiserName).to.equal('fake advertiser name');
       expect(result[1].meta).to.not.have.key('advertiserName');
     });
+  });
 
   describe('getUserSyncs', function() {
     let expectedIframeSyncUrl = 'https://eb2.3lift.com/sync?gdpr=true&cmp_cs=' + GDPR_CONSENT_STR + '&';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- add `GDVID=28`
- add `meta.advertiserDomains`
- add unit tests for more multiimp cases
- update isBidRequest validation to only check for inventoryCode


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
