### PR TITLE
TL-18499: Add advertiserDomains support

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -293,6 +293,10 @@ function _buildResponseObject(bidderRequest, bid) {
     if (bid.advertiser_name) {
       bidResponse.meta.advertiserName = bid.advertiser_name;
     }
+
+    if (bid.adomain && bid.adomain.length) {
+      bidResponse.meta.advertiserDomains = bid.adomain;
+    }
   };
   return bidResponse;
 }

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -638,7 +638,8 @@ describe('triplelift adapter', function () {
               ad: 'ad-markup',
               iurl: 'https://s.adroll.com/a/IYR/N36/IYRN366MFVDITBAGNNT5U6.jpg',
               tl_source: 'tlx',
-              advertiser_name: 'fake advertiser name'
+              advertiser_name: 'fake advertiser name',
+              adomain: ['basspro.com', 'internetalerts.org']
             },
             {
               imp_id: 1,
@@ -746,6 +747,13 @@ describe('triplelift adapter', function () {
       let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
       expect(result[0].meta.advertiserName).to.equal('fake advertiser name');
       expect(result[1].meta).to.not.have.key('advertiserName');
+    });
+
+    it('should include the advertiser domain array in the meta field if available', function () {
+      let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
+      expect(result[0].meta.advertiserDomains[0]).to.equal('basspro.com');
+      expect(result[0].meta.advertiserDomains[1]).to.equal('internetalerts.org');
+      expect(result[1].meta).to.not.have.key('advertiserDomains');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Add adomain to prebid_c2s supplier bid responses. Don't touch advertiser_name.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

https://triplelift.atlassian.net/browse/TL-18499