### PR TITLE
TL-17557: Incorrectly passing FPD KVs

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -114,8 +114,7 @@ function _buildPostBody(bidRequests) {
     let imp = {
       id: index,
       tagid: bidRequest.params.inventoryCode,
-      floor: _getFloor(bidRequest),
-      fpd: _getAdUnitFpd(bidRequest)
+      floor: _getFloor(bidRequest)
     };
     // remove the else to support multi-imp
     if (_isInstreamBidRequest(bidRequest)) {
@@ -123,6 +122,9 @@ function _buildPostBody(bidRequests) {
     } else if (bidRequest.mediaTypes.banner) {
       imp.banner = { format: _sizes(bidRequest.sizes) };
     };
+    if (!utils.isEmpty(bidRequest.fpd)) {
+      imp.fpd = _getAdUnitFpd(bidRequest.fpd);
+    }
     return imp;
   });
 
@@ -203,11 +205,17 @@ function _getGlobalFpd() {
   return fpd;
 }
 
-function _getAdUnitFpd(bid) {
-  if (!utils.isEmpty(bid.fpd)) {
-    return bid.fpd;
+function _getAdUnitFpd(adUnitFpd) {
+  let fpd = {};
+  let context = {};
+
+  _addEntries(context, adUnitFpd.context);
+
+  if (!utils.isEmpty(context)) {
+    fpd.context = context;
   }
-  return null;
+
+  return fpd;
 }
 
 function _addEntries(target, source) {

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -184,12 +184,21 @@ function _getFloor (bid) {
 
 function _getGlobalFpd() {
   let fpd = {};
+  let context = {}
+  let user = {};
+
   const fpdContext = Object.assign({}, config.getConfig('fpd.context'));
   const fpdUser = Object.assign({}, config.getConfig('fpd.user'));
 
-  _addEntries(fpd, fpdContext);
-  _addEntries(fpd, fpdUser);
+  _addEntries(context, fpdContext);
+  _addEntries(user, fpdUser);
 
+  if (!utils.isEmpty(context)) {
+    fpd.context = context;
+  }
+  if (!utils.isEmpty(user)) {
+    fpd.user = user;
+  }
   return fpd;
 }
 

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -114,7 +114,8 @@ function _buildPostBody(bidRequests) {
     let imp = {
       id: index,
       tagid: bidRequest.params.inventoryCode,
-      floor: _getFloor(bidRequest)
+      floor: _getFloor(bidRequest),
+      fpd: _getAdUnitFpd(bidRequest)
     };
     // remove the else to support multi-imp
     if (_isInstreamBidRequest(bidRequest)) {
@@ -199,6 +200,11 @@ function _getGlobalFpd() {
   if (!utils.isEmpty(user)) {
     fpd.user = user;
   }
+  return fpd;
+}
+
+function _getAdUnitFpd(bid) {
+  let fpd = {};
   return fpd;
 }
 

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -186,9 +186,9 @@ function _getFloor (bid) {
 }
 
 function _getGlobalFpd() {
-  let fpd = {};
-  let context = {}
-  let user = {};
+  const fpd = {};
+  const context = {}
+  const user = {};
 
   const fpdContext = Object.assign({}, config.getConfig('fpd.context'));
   const fpdUser = Object.assign({}, config.getConfig('fpd.user'));
@@ -206,8 +206,8 @@ function _getGlobalFpd() {
 }
 
 function _getAdUnitFpd(adUnitFpd) {
-  let fpd = {};
-  let context = {};
+  const fpd = {};
+  const context = {};
 
   _addEntries(context, adUnitFpd.context);
 

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -204,8 +204,10 @@ function _getGlobalFpd() {
 }
 
 function _getAdUnitFpd(bid) {
-  let fpd = {};
-  return fpd;
+  if (!utils.isEmpty(bid.fpd)) {
+    return bid.fpd;
+  }
+  return null;
 }
 
 function _addEntries(target, source) {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -143,6 +143,14 @@ describe('triplelift adapter', function () {
           auctionId: '1d1a030790a475',
           userId: {},
           schain,
+          fpd: {
+            context: {
+              pbAdSlot: 'homepage-top-rect',
+              data: {
+                adUnitSpecificAttribute: 123
+              }
+            }
+          }
         },
         {
           bidder: 'triplelift',
@@ -597,7 +605,7 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
-    it('should send fpd on root level ext if kvps are available', function() {
+    it('should send global config fpd if kvps are available', function() {
       const sens = null;
       const category = ['news', 'weather', 'hurricane'];
       const pmp_elig = 'true';
@@ -621,6 +629,13 @@ describe('triplelift adapter', function () {
       expect(payload.ext.fpd.user).to.not.exist;
       expect(payload.ext.fpd.context).to.haveOwnProperty('category');
       expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');
+    });
+    it.only('should send ad unit fpd if kvps are available', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[0].fpd.context).to.haveOwnProperty('pbAdSlot');
+      expect(request.data.imp[0].fpd.context).to.haveOwnProperty('data');
+      expect(request.data.imp[0].fpd.context.data).to.haveOwnProperty('adUnitSpecificAttribute');
+      expect(request.data.imp[1].fpd).to.not.exist;
     });
   });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -605,7 +605,7 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
-    it.only('should send global config fpd if kvps are available', function() {
+    it('should send global config fpd if kvps are available', function() {
       const sens = null;
       const category = ['news', 'weather', 'hurricane'];
       const pmp_elig = 'true';

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -630,7 +630,7 @@ describe('triplelift adapter', function () {
       expect(payload.ext.fpd.context).to.haveOwnProperty('category');
       expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');
     });
-    it.only('should send ad unit fpd if kvps are available', function() {
+    it('should send ad unit fpd if kvps are available', function() {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].fpd.context).to.haveOwnProperty('pbAdSlot');
       expect(request.data.imp[0].fpd.context).to.haveOwnProperty('data');

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -605,17 +605,19 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
-    it('should send global config fpd if kvps are available', function() {
+    it.only('should send global config fpd if kvps are available', function() {
       const sens = null;
       const category = ['news', 'weather', 'hurricane'];
       const pmp_elig = 'true';
       const fpd = {
         context: {
-          pmp_elig,
-          category,
+          pmp_elig: pmp_elig,
+          data: {
+            category: category
+          }
         },
         user: {
-          sens,
+          sens: sens,
         }
       }
       sandbox.stub(config, 'getConfig').callsFake(key => {
@@ -627,7 +629,7 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
       expect(payload.ext.fpd.user).to.not.exist;
-      expect(payload.ext.fpd.context).to.haveOwnProperty('category');
+      expect(payload.ext.fpd.context.data).to.haveOwnProperty('category');
       expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');
     });
     it('should send ad unit fpd if kvps are available', function() {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -618,9 +618,9 @@ describe('triplelift adapter', function () {
       });
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
-      expect(payload.ext.fpd).to.not.haveOwnProperty('sens');
-      expect(payload.ext.fpd).to.haveOwnProperty('category');
-      expect(payload.ext.fpd).to.haveOwnProperty('pmp_elig');
+      expect(payload.ext.fpd.user).to.not.exist;
+      expect(payload.ext.fpd.context).to.haveOwnProperty('category');
+      expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');
     });
   });
 


### PR DESCRIPTION
## Summary
- An issue was raised regarding how we interpret the `fpd` object from publishers: https://github.com/prebid/Prebid.js/issues/6000
- We were incorrectly setting KVs at the root level of the `fpd` object before making a request to TLX. Instead we need to make sure we are properly populating `fpd.context` and `fpd.user` with KVs and subsequently passing those KVs to TLX. 
- _We need to make sure the exchange can properly handle the `fpd` object that we pass before we make any changes to the Prebid adapter_

## Docs
- TL Spec: [Supporting Prebid FPD (first party data)](https://docs.google.com/document/d/1W__RgBaXSZbEmlKLC5josJi2L35j1OdeDgbJJFnEBfM/edit#heading=h.r7j03iasf953)
- Prebid fpd example: https://docs.prebid.org/features/firstPartyData.html#in-page-examples

## Original TL Ticket
https://triplelift.atlassian.net/browse/TL-17557