### PR TITLE
TL-19515 Support video floors

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -175,7 +175,7 @@ function _getFloor (bid) {
     const floorInfo = bid.getFloor({
       currency: 'USD',
       mediaType: _isInstreamBidRequest(bid) ? 'video' : 'banner',
-      size: _sizes(bid.sizes)
+      size: '*'
     });
     if (typeof floorInfo === 'object' &&
     floorInfo.currency === 'USD' && !isNaN(parseFloat(floorInfo.floor))) {

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -174,7 +174,7 @@ function _getFloor (bid) {
   if (typeof bid.getFloor === 'function') {
     const floorInfo = bid.getFloor({
       currency: 'USD',
-      mediaType: 'banner',
+      mediaType: _isInstreamBidRequest(bid) ? 'video' : 'banner',
       size: _sizes(bid.sizes)
     });
     if (typeof floorInfo === 'object' &&

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -597,12 +597,17 @@ describe('triplelift adapter', function () {
       expect(payload.ext).to.deep.equal(undefined);
     });
     it('should get floor from floors module if available', function() {
-      const floorInfo = {
-        currency: 'USD',
-        floor: 1.99
-      };
+      let floorInfo;
       bidRequests[0].getFloor = () => floorInfo;
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+
+      // standard float response; expected functionality of floors module
+      floorInfo = { currency: 'USD', floor: 1.99 };
+      let request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[0].floor).to.equal(1.99);
+
+      // if string response, convert to float
+      floorInfo = { currency: 'USD', floor: '1.99' };
+      request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
     it('should call getFloor with the correct parameters based on mediaType', function() {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -605,6 +605,42 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].floor).to.equal(1.99);
     });
+    it('should call getFloor with the correct parameters based on mediaType', function() {
+      bidRequests.forEach(request => {
+        request.getFloor = () => {};
+        sinon.spy(request, 'getFloor')
+      });
+
+      tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+
+      // banner
+      expect(bidRequests[0].getFloor.calledWith({
+        currency: 'USD',
+        mediaType: 'banner',
+        size: '*'
+      })).to.be.true;
+
+      // instream
+      expect(bidRequests[1].getFloor.calledWith({
+        currency: 'USD',
+        mediaType: 'video',
+        size: '*'
+      })).to.be.true;
+
+      // banner and incomplete video (POST will only include banner)
+      expect(bidRequests[3].getFloor.calledWith({
+        currency: 'USD',
+        mediaType: 'banner',
+        size: '*'
+      })).to.be.true;
+
+      // banner and instream (POST will only include video)
+      expect(bidRequests[5].getFloor.calledWith({
+        currency: 'USD',
+        mediaType: 'video',
+        size: '*'
+      })).to.be.true;
+    });
     it('should send global config fpd if kvps are available', function() {
       const sens = null;
       const category = ['news', 'weather', 'hurricane'];


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Other

## Description of change
Addresses an issue with our getFloors method where 'banner' is used as a static variable as opposed to dynamically checking the ad unit's mediaType. For any pubs using the floor module this is likely leading to our adapter retrieving a floor lower than expected. Additionally refactors 'size' param to correctly use '*' since our adapter does not use size specific floors. 
[See Prebid docs on how to use getFloors method](https://docs.prebid.org/dev-docs/modules/floors.html#bid-adapter-interface)

![image](https://user-images.githubusercontent.com/75995508/105763352-afa12600-5f23-11eb-8ca8-51088267f467.png)

### Testing
Adds an additional layer of testing to cover the above: 'should call getFloor with the correct parameters based on mediaType'

Adds an additional edge case to an existing test around floors: 'should get floor from floors module if available'