### PR TITLE
TL-19844: removes duplicate eids from POST call

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -129,9 +129,9 @@ function _buildPostBody(bidRequests) {
   });
 
   let eids = [
-    ...getUnifiedIdEids(bidRequests),
-    ...getIdentityLinkEids(bidRequests),
-    ...getCriteoEids(bidRequests)
+    ...getUnifiedIdEids([bidRequests[0]]),
+    ...getIdentityLinkEids([bidRequests[0]]),
+    ...getCriteoEids([bidRequests[0]])
   ];
 
   if (eids.length > 0) {
@@ -239,20 +239,20 @@ function _getExt(schain, fpd) {
   return ext;
 }
 
-function getUnifiedIdEids(bidRequests) {
-  return getEids(bidRequests, 'tdid', 'adserver.org', 'TDID');
+function getUnifiedIdEids(bidRequest) {
+  return getEids(bidRequest, 'tdid', 'adserver.org', 'TDID');
 }
 
-function getIdentityLinkEids(bidRequests) {
-  return getEids(bidRequests, 'idl_env', 'liveramp.com', 'idl');
+function getIdentityLinkEids(bidRequest) {
+  return getEids(bidRequest, 'idl_env', 'liveramp.com', 'idl');
 }
 
-function getCriteoEids(bidRequests) {
-  return getEids(bidRequests, 'criteoId', 'criteo.com', 'criteoId');
+function getCriteoEids(bidRequest) {
+  return getEids(bidRequest, 'criteoId', 'criteo.com', 'criteoId');
 }
 
-function getEids(bidRequests, type, source, rtiPartner) {
-  return bidRequests
+function getEids(bidRequest, type, source, rtiPartner) {
+  return bidRequest
     .map(getUserId(type)) // bids -> userIds of a certain type
     .filter((x) => !!x) // filter out null userIds
     .map(formatEid(source, rtiPartner)); // userIds -> eid objects

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -512,9 +512,9 @@ describe('triplelift adapter', function () {
       const criteoId = '53e30ea700424f7bbdd793b02abc5d7';
 
       const bidRequestsMultiple = [
-        { ...bidRequests[0], userId: { tdid: tdidId } },
-        { ...bidRequests[0], userId: { idl_env: idlEnvId } },
-        { ...bidRequests[0], userId: { criteoId: criteoId } }
+        { ...bidRequests[0], userId: { tdid: tdidId, idl_env: idlEnvId, criteoId } },
+        { ...bidRequests[0], userId: { tdid: tdidId, idl_env: idlEnvId, criteoId } },
+        { ...bidRequests[0], userId: { tdid: tdidId, idl_env: idlEnvId, criteoId } }
       ];
 
       const request = tripleliftAdapterSpec.buildRequests(bidRequestsMultiple, bidderRequest);

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -506,7 +506,7 @@ describe('triplelift adapter', function () {
       });
     });
 
-    it('should add user ids from multiple bid requests', function () {
+    it('should consolidate user ids from multiple bid requests', function () {
       const tdidId = '6bca7f6b-a98a-46c0-be05-6020f7604598';
       const idlEnvId = 'XY6104gr0njcH9UDIR7ysFFJcm2XNpqeJTYslleJ_cMlsFOfZI';
       const criteoId = '53e30ea700424f7bbdd793b02abc5d7';
@@ -553,6 +553,9 @@ describe('triplelift adapter', function () {
           ]
         }
       });
+
+      expect(payload.user.ext.eids).to.be.an('array');
+      expect(payload.user.ext.eids).to.have.lengthOf(3);
     });
 
     it('should return a query string for TL call', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
### Adapter
Minor update to pass the various `getXXXEids` methods a single bidRequest instead of the entire array of valid bidRequests, preventing the duplicate values currently being passed in the TLX call. 
### _spec / Unit tests
Revised test to accurately reflect an array of bidRequests where all userId objects would be the same

