### PR TITLE
TL-24341: Outstream support

### DIFF
--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -411,9 +411,9 @@ describe('triplelift adapter', function () {
       expect(payload.imp[1].floor).to.equal(1.0);
       expect(payload.imp[1].video).to.exist.and.to.be.a('object');
       // banner and outstream video
-      expect(payload.imp[2]).to.not.have.property('video');
-      expect(payload.imp[2]).to.have.property('banner');
-      expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
+      expect(payload.imp[2]).to.have.property('video');
+      expect(payload.imp[2]).to.not.have.property('banner');
+      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
       // banner and incomplete video
       expect(payload.imp[3]).to.not.have.property('video');
       expect(payload.imp[3]).to.have.property('banner');
@@ -427,9 +427,9 @@ describe('triplelift adapter', function () {
       expect(payload.imp[5]).to.have.property('video');
       expect(payload.imp[5].video).to.exist.and.to.be.a('object');
       // banner and outream video and native
-      expect(payload.imp[6]).to.not.have.property('video');
-      expect(payload.imp[6]).to.have.property('banner');
-      expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
+      expect(payload.imp[6]).to.have.property('video');
+      expect(payload.imp[6]).to.not.have.property('banner');
+      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
     });
 
     it('should add tdid to the payload if included', function () {


### PR DESCRIPTION
https://triplelift.atlassian.net/browse/TL-24341

## Type of change
- [X] Feature

## Description of change
- Allows adunits configured as 'outstream' to be sent to endpoint
- Still prioritizes video when video and banner are set in adunit simultaneously / multi-imp is still not a possibility, ie., requests are still always either banner OR video (need to discuss this further)
- Outstream gets same TTL as Instream


## TO DO
Questions:
- Does outstream need any special treatment around (I don't believe so as outstream just returns vast, same as instream):
```if (_isVideoBidRequest(breq)) {
      bidResponse.vastXml = bid.ad;
```
- Write outstream specific unit tests (discussion on how to treat video + banner combinations [here](https://triplelift.atlassian.net/browse/TL-24341?focusedCommentId=253433))
    - both instream and outstream on adunit definition