### PR TITLE
TL-26965: deprecate getLegacyFpd

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -192,9 +192,9 @@ function _getGlobalFpd() {
   const fpd = {};
   const context = {}
   const user = {};
-  const ortbData = config.getLegacyFpd(config.getConfig('ortb2')) || {};
+  const ortbData = config.getConfig('ortb2') || {};
 
-  const fpdContext = Object.assign({}, ortbData.context);
+  const fpdContext = Object.assign({}, ortbData.site);
   const fpdUser = Object.assign({}, ortbData.user);
 
   _addEntries(context, fpdContext);

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -812,7 +812,6 @@ describe('triplelift adapter', function () {
       });
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
-      console.log(JSON.stringify(payload))
       expect(payload.ext.fpd.user).to.not.exist;
       expect(payload.ext.fpd.context.ext.data).to.haveOwnProperty('category');
       expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -812,8 +812,9 @@ describe('triplelift adapter', function () {
       });
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       const { data: payload } = request;
+      console.log(JSON.stringify(payload))
       expect(payload.ext.fpd.user).to.not.exist;
-      expect(payload.ext.fpd.context.data).to.haveOwnProperty('category');
+      expect(payload.ext.fpd.context.ext.data).to.haveOwnProperty('category');
       expect(payload.ext.fpd.context).to.haveOwnProperty('pmp_elig');
     });
     it('should send ad unit fpd if kvps are available', function() {


### PR DESCRIPTION
https://triplelift.atlassian.net/browse/TL-26965

most importantly, getLegacyFpd in getting deprecated in v7 so we need to get rid of it - plus we don't use fpd right now anyway. 
[Losing `user.data` after getLegacyFpd · Issue #8264 · prebid/Prebid.js](https://github.com/prebid/Prebid.js/issues/8264#issuecomment-1092220128)

This method is causing us to miss out on user.data fpd, which is going to be required for the 1PlusX integration. We need to deprecate this method and only reference the new ortb2 for first party data. 

The above functionality is not intended. I reported the issue [here](https://github.com/prebid/Prebid.js/issues/8264) but not many adapters are using this legacy method anymore and so the reco is to deprecate from adapters.