### PR TITLE
TL-27574: 1PlusX boilerplate

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -2,6 +2,7 @@ import { tryAppendQueryString, logMessage, logError, isEmpty, isStr, isPlainObje
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
+import {getStorageManager} from '../src/storageManager.js';
 
 const GVLID = 28;
 const BIDDER_CODE = 'triplelift';
@@ -10,6 +11,7 @@ const BANNER_TIME_TO_LIVE = 300;
 const INSTREAM_TIME_TO_LIVE = 3600;
 let gdprApplies = true;
 let consentString = null;
+const storage = getStorageManager({gvlid: GVLID, bidderCode: BIDDER_CODE});
 
 export const tripleliftAdapterSpec = {
   gvlid: GVLID,
@@ -197,6 +199,8 @@ function _getGlobalFpd() {
   const context = {}
   const user = {};
   const ortbData = config.getConfig('ortb2') || {};
+  const oneplusx = storage.getDataFromLocalStorage('1plusx')
+  console.log('1plusx', JSON.parse(oneplusx))
 
   const fpdContext = Object.assign({}, ortbData.site);
   const fpdUser = Object.assign({}, ortbData.user);


### PR DESCRIPTION
## Description

**Epic**: https://triplelift.atlassian.net/browse/TL-27574

**Summary**: 
- Must follow oRTB outline for user.data noted [here](https://triplelift.atlassian.net/wiki/spaces/ENG/pages/3028058120/Impression+mapping+engine#Integrations)

Can use the following for local testing:
```
localStorage.setItem(
        '1plusx',
        JSON.stringify({
          v: 1,
          s: 'ySRdArquXuBolr/cVv0UNqrJhTO4QZsbNH/t+2kR3gXjbA==',
          t: '/yVtBrquXuBolr/cVv0UNtx1mssdLYeKFhWFI3Dq1dJnug=='
        })
      );
```
## Test Scenarios
The following scenarios have been accounted for:
- [x] Global first party `user.data` object exists: `ortb2.user.data` exists
- [x] Global first party `user.data` object **does not exist**. Only `ortb2.user` exists
- [x] Global first party `user` object **does not exist**. Only `ortb2` exists
- [x] Global first party data **does not currently exist**. `ortb2` object is empty
- [x] 1plusX segments are not available on the window object