### PR TITLE
TL-28813: Add Transaction ID

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -48,6 +48,8 @@ export const tripleliftAdapterSpec = {
       }
     }
 
+    utils.deepSetValue(data, 'source.tid', bidRequests[0].auctionId);
+
     if (bidderRequest && bidderRequest.uspConsent) {
       tlCall = tryAppendQueryString(tlCall, 'us_privacy', bidderRequest.uspConsent);
     }

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -440,6 +440,12 @@ describe('triplelift adapter', function () {
       expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
     });
 
+    it('should include transaction id', function () {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.source.tid).to.exist;
+      expect(request.data.source.tid).and.to.deep.equal(bidRequests[0].auctionId);
+    });
+
     it('should add tdid to the payload if included', function () {
       const id = '6bca7f6b-a98a-46c0-be05-6020f7604598';
       bidRequests[0].userId.tdid = id;


### PR DESCRIPTION
Ticket: https://triplelift.atlassian.net/browse/TL-28813 - conversation screen grab is included in ticket

This PR allows for our bid adapter to pass auction ID to transaction ID. This PR includes 1 test - to check if the data object includes source.tid. We are using the bidRequests[0] similarly to other adapters that pass multiple bid requests.