### PR TITLE
TL-32803: update referrer logic

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -29,7 +29,7 @@ export const tripleliftAdapterSpec = {
     tlCall = tryAppendQueryString(tlCall, 'v', '$prebid.version$');
 
     if (bidderRequest && bidderRequest.refererInfo) {
-      let referrer = bidderRequest?.refererInfo?.topmostLocation || bidderRequest?.refererInfo?.page;
+      let referrer = bidderRequest.refererInfo.page;
       tlCall = tryAppendQueryString(tlCall, 'referrer', referrer);
     }
 


### PR DESCRIPTION
## Summary
Prebid updated its' logic to retrieve `referrerInfo.page` so that adapters can just reference `referrerInfo.page` rather than having to implement a decision tree.

Issue and resolution can be found here:
**Issue**: https://github.com/prebid/Prebid.js/issues/9185
**Update**: https://github.com/prebid/Prebid.js/pull/9241
