### PR TITLE
TL-34204: Add support for GPP

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -154,6 +154,10 @@ function _buildPostBody(bidRequests, bidderRequest) {
   if (!isEmpty(ext)) {
     data.ext = ext;
   }
+
+  if (bidderRequest?.ortb2?.regs?.gpp) {
+    data.regs = Object.assign({}, bidderRequest.ortb2.regs);
+  }
   return data;
 }
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -1168,6 +1168,19 @@ describe('triplelift adapter', function () {
         }
       })
     });
+    it('should add gpp consent data to bid request object if gpp data exists', function() {
+      bidderRequest.ortb2 = {
+        regs: {
+          'gpp': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+          'gpp_sid': [7]
+        }
+      }
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.regs).to.deep.equal({
+        'gpp': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+        'gpp_sid': [7]
+      })
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Adding support for GPP:
- [x] Add GPP data to bid request 
- [ ] Add specific GPP parameters to user sync pixel (will be added in a separate PR - not yet solutioned/supported internally)

## Other information
- Added GPP data at [recommended](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectregs) location in bid request object
