### PR TITLE
TL-36204: Copy TID to Impression Ext

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -111,6 +111,7 @@ function _getSyncType(syncOptions) {
 
 function _buildPostBody(bidRequests, bidderRequest) {
   let data = {};
+  let impExt = {};
   let { schain } = bidRequests[0];
   const globalFpd = _getGlobalFpd(bidderRequest);
 
@@ -131,7 +132,11 @@ function _buildPostBody(bidRequests, bidderRequest) {
 
     if (!isEmpty(bidRequest.ortb2Imp)) {
       imp.fpd = _getAdUnitFpd(bidRequest.ortb2Imp);
-      imp.ext = _getImpExt(bidRequest.ortb2Imp);
+      impExt = _getImpExt(bidRequest.ortb2Imp);
+    }
+
+    if (typeof impExt !== 'undefined') {
+      imp.ext = impExt;
     }
 
     return imp;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Copying TID and other `ortb2.ext` data to `imp.ext` in supplier bid requests. This will be a step in the right direction in terms of industry standardization
