### PR TITLE
TL-36204: Copying ortb2Imp.ext to impression ext obj

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -111,6 +111,7 @@ function _getSyncType(syncOptions) {
 
 function _buildPostBody(bidRequests, bidderRequest) {
   let data = {};
+  let impExt = {};
   let { schain } = bidRequests[0];
   const globalFpd = _getGlobalFpd(bidderRequest);
 
@@ -131,7 +132,13 @@ function _buildPostBody(bidRequests, bidderRequest) {
 
     if (!isEmpty(bidRequest.ortb2Imp)) {
       imp.fpd = _getAdUnitFpd(bidRequest.ortb2Imp);
+      impExt = _getImpExt(bidRequest.ortb2Imp);
     }
+
+    if (typeof impExt !== 'undefined') {
+      imp.ext = impExt;
+    }
+
     return imp;
   });
 
@@ -281,6 +288,16 @@ function _getAdUnitFpd(adUnitFpd) {
   }
 
   return fpd;
+}
+
+function _getImpExt(ortb2Imp) {
+  let ext = {};
+
+  if (!isEmpty(ortb2Imp.ext)) {
+    ext = { ...ortb2Imp.ext }
+  }
+
+  return ext;
 }
 
 function _addEntries(target, source) {

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -1,4 +1,4 @@
-import { tryAppendQueryString, logMessage, logError, isEmpty, isStr, isPlainObject, isArray, logWarn, deepClone } from '../src/utils.js';
+import { tryAppendQueryString, logMessage, logError, isEmpty, isStr, isPlainObject, isArray, logWarn } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
@@ -135,7 +135,7 @@ function _buildPostBody(bidRequests, bidderRequest) {
 
       // preferred method for extracting ortb2Imp.ext
       if (!isEmpty(bidRequest.ortb2Imp.ext)) {
-        imp.ext = deepClone(bidRequest.ortb2Imp.ext)
+        imp.ext = { ...bidRequest.ortb2Imp.ext };
       }
     }
 

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -1,4 +1,4 @@
-import { tryAppendQueryString, logMessage, logError, isEmpty, isStr, isPlainObject, isArray, logWarn } from '../src/utils.js';
+import { tryAppendQueryString, logMessage, logError, isEmpty, isStr, isPlainObject, isArray, logWarn, deepClone } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
@@ -111,7 +111,6 @@ function _getSyncType(syncOptions) {
 
 function _buildPostBody(bidRequests, bidderRequest) {
   let data = {};
-  let impExt = {};
   let { schain } = bidRequests[0];
   const globalFpd = _getGlobalFpd(bidderRequest);
 
@@ -131,12 +130,13 @@ function _buildPostBody(bidRequests, bidderRequest) {
     }
 
     if (!isEmpty(bidRequest.ortb2Imp)) {
+      // legacy method for extracting ortb2Imp.ext
       imp.fpd = _getAdUnitFpd(bidRequest.ortb2Imp);
-      impExt = _getImpExt(bidRequest.ortb2Imp);
-    }
 
-    if (typeof impExt !== 'undefined') {
-      imp.ext = impExt;
+      // preferred method for extracting ortb2Imp.ext
+      if (!isEmpty(bidRequest.ortb2Imp.ext)) {
+        imp.ext = deepClone(bidRequest.ortb2Imp.ext)
+      }
     }
 
     return imp;
@@ -288,16 +288,6 @@ function _getAdUnitFpd(adUnitFpd) {
   }
 
   return fpd;
-}
-
-function _getImpExt(ortb2Imp) {
-  let ext = {};
-
-  if (!isEmpty(ortb2Imp.ext)) {
-    ext = { ...ortb2Imp.ext }
-  }
-
-  return ext;
 }
 
 function _addEntries(target, source) {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -139,15 +139,13 @@ describe('triplelift adapter', function () {
           sizes: [[300, 250], [300, 600], [1, 1, 1], ['flex']],
           bidId: '30b31c1838de1e',
           bidderRequestId: '22edbae2733bf6',
+          transactionId: '173f49a8-7549-4218-a23c-e7ba59b47229',
           auctionId: '1d1a030790a475',
           userId: {},
           schain,
           ortb2Imp: {
             ext: {
-              data: {
-                pbAdSlot: 'homepage-top-rect',
-                adUnitSpecificAttribute: 123
-              }
+              tid: '173f49a8-7549-4218-a23c-e7ba59b47229'
             }
           }
         },
@@ -178,6 +176,15 @@ describe('triplelift adapter', function () {
           auctionId: '1d1a030790a475',
           userId: {},
           schain,
+          ortb2Imp: {
+            ext: {
+              data: {
+                pbAdSlot: 'homepage-top-rect',
+                adUnitSpecificAttribute: 123
+              },
+              tid: '173f49a8-7549-4218-a23c-e7ba59b47229'
+            }
+          }
         },
         // banner and outstream video
         {
@@ -689,6 +696,29 @@ describe('triplelift adapter', function () {
       expect(payload.imp[13].video.placement).to.equal(3);
     });
 
+    it('should add tid to imp.ext if transactionId exists', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[0].ext.tid).to.exist.and.be.a('string');
+      expect(request.data.imp[0].ext.tid).to.equal('173f49a8-7549-4218-a23c-e7ba59b47229');
+    });
+
+    it('should copy entire impression ext object', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[1].ext).to.haveOwnProperty('tid');
+      expect(request.data.imp[1].ext).to.haveOwnProperty('data');
+      expect(request.data.imp[1].ext.data).to.haveOwnProperty('adUnitSpecificAttribute');
+      expect(request.data.imp[1].ext.data).to.haveOwnProperty('pbAdSlot');
+      expect(request.data.imp[1].ext).to.deep.equal(
+        {
+          data: {
+            pbAdSlot: 'homepage-top-rect',
+            adUnitSpecificAttribute: 123
+          },
+          tid: '173f49a8-7549-4218-a23c-e7ba59b47229'
+        }
+      );
+    });
+
     it('should add tdid to the payload if included', function () {
       const id = '6bca7f6b-a98a-46c0-be05-6020f7604598';
       bidRequests[0].userId.tdid = id;
@@ -1103,10 +1133,10 @@ describe('triplelift adapter', function () {
     });
     it('should send ad unit fpd if kvps are available', function() {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.imp[0].fpd.context).to.haveOwnProperty('data');
-      expect(request.data.imp[0].fpd.context.data).to.haveOwnProperty('pbAdSlot');
-      expect(request.data.imp[0].fpd.context.data).to.haveOwnProperty('adUnitSpecificAttribute');
-      expect(request.data.imp[1].fpd).to.not.exist;
+      expect(request.data.imp[1].fpd.context).to.haveOwnProperty('data');
+      expect(request.data.imp[1].fpd.context.data).to.haveOwnProperty('pbAdSlot');
+      expect(request.data.imp[1].fpd.context.data).to.haveOwnProperty('adUnitSpecificAttribute');
+      expect(request.data.imp[2].fpd).to.not.exist;
     });
     it('should send 1PlusX data as fpd if localStorage is available and no other fpd is defined', function() {
       sandbox.stub(storage, 'getDataFromLocalStorage').callsFake(() => '{"kid":1,"s":"ySRdArquXuBolr/cVv0UNqrJhTO4QZsbNH/t+2kR3gXjbA==","t":"/yVtBrquXuBolr/cVv0UNtx1mssdLYeKFhWFI3Dq1dJnug=="}');

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -252,6 +252,11 @@ describe('triplelift adapter', function () {
           auctionId: '1d1a030790a475',
           userId: {},
           schain,
+          ortb2Imp: {
+            misc: {
+              test: 1
+            }
+          }
         },
         // incomplete banner and incomplete video
         {
@@ -700,6 +705,16 @@ describe('triplelift adapter', function () {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.imp[0].ext.tid).to.exist.and.be.a('string');
       expect(request.data.imp[0].ext.tid).to.equal('173f49a8-7549-4218-a23c-e7ba59b47229');
+    });
+
+    it('should not add impression ext object if ortb2Imp does not exist', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[2].ext).to.not.exist;
+    });
+
+    it('should not add impression ext object if ortb2Imp.ext does not exist', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[3].ext).to.not.exist;
     });
 
     it('should copy entire impression ext object', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Copying entire `ortb2Imp.ext` object to `imp.ext` in supplier bid requests to standardize the location of certain data
