### PR TITLE
PAAPI: backup code to merge configs

### DIFF
--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -1549,7 +1549,7 @@ describe('triplelift adapter', function () {
       expect(result[3].meta.networkId).to.equal('5989');
     });
 
-    it('should return fledgeAuctionConfigs if PAAPI response is received', function() {
+    it('should return fledgeAuctionConfigs if PAAPI response is received', function () {
       response.body.paapi = [
         {
           imp_id: '0',
@@ -1572,32 +1572,42 @@ describe('triplelift adapter', function () {
               'https://some_other_buyer.com': { b: 2 }
             }
           }
+        },
+        {
+          imp_id: '2',
+          auctionConfig: {
+            seller: 'https://3lift.com',
+            decisionLogicUrl: 'https://3lift.com/decision_logic.js',
+            interestGroupBuyers: ['https://a_third_buyer.com'],
+            perBuyerSignals: {
+              'https://a_third_buyer.com': { c: 3 }
+            }
+          }
         }
       ];
 
-      let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
+      let result = tripleliftAdapterSpec.interpretResponse(response, { bidderRequest });
 
       expect(result).to.have.property('bids');
       expect(result).to.have.property('fledgeAuctionConfigs');
       expect(result.fledgeAuctionConfigs.length).to.equal(2);
       expect(result.fledgeAuctionConfigs[0].bidId).to.equal('30b31c1838de1e');
       expect(result.fledgeAuctionConfigs[1].bidId).to.equal('73edc0ba8de203');
-      expect(result.fledgeAuctionConfigs[0].config).to.deep.equal(
-        {
-          'seller': 'https://3lift.com',
-          'decisionLogicUrl': 'https://3lift.com/decision_logic.js',
-          'interestGroupBuyers': ['https://some_buyer.com'],
-          'perBuyerSignals': { 'https://some_buyer.com': { 'a': 1 } }
+      expect(result.fledgeAuctionConfigs[0].config).to.deep.equal({
+        seller: 'https://3lift.com',
+        decisionLogicUrl: 'https://3lift.com/decision_logic.js',
+        interestGroupBuyers: ['https://some_buyer.com'],
+        perBuyerSignals: { 'https://some_buyer.com': { a: 1 } }
+      });
+      expect(result.fledgeAuctionConfigs[1].config).to.deep.equal({
+        seller: 'https://3lift.com',
+        decisionLogicUrl: 'https://3lift.com/decision_logic.js',
+        interestGroupBuyers: ['https://some_other_buyer.com', 'https://a_third_buyer.com'],
+        perBuyerSignals: {
+          'https://some_other_buyer.com': { b: 2 },
+          'https://a_third_buyer.com': { c: 3 }
         }
-      );
-      expect(result.fledgeAuctionConfigs[1].config).to.deep.equal(
-        {
-          'seller': 'https://3lift.com',
-          'decisionLogicUrl': 'https://3lift.com/decision_logic.js',
-          'interestGroupBuyers': ['https://some_other_buyer.com'],
-          'perBuyerSignals': { 'https://some_other_buyer.com': { 'b': 2 } }
-        }
-      );
+      });
     });
   });
 


### PR DESCRIPTION
Backup code in the event auction configs with duplicate imp_id's (resulting in identical BidId's being returned to prebid) are causing issues. 