### PR TITLE
MPY-161: Adding support for video.plcmt

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -247,7 +247,10 @@ function _getORTBVideo(bidRequest) {
   }
   if (video.context === 'outstream') {
     if (!video.placement) {
-      video.placement = 4
+      video.placement = 3
+    } else if ([3, 4, 5].indexOf(video.placement) === -1) {
+      logMessage(`video.placement value of ${video.placement} is invalid for outstream context. Setting placement to 3`)
+      video.placement = 3
     }
     if (!video.plcmt) {
       video.plcmt = 4;

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -241,13 +241,16 @@ function _getORTBVideo(bidRequest) {
     if (!video.placement) {
       video.placement = 1;
     }
+    if (!video.plcmt) {
+      video.plcmt = 1;
+    }
   }
   if (video.context === 'outstream') {
     if (!video.placement) {
-      video.placement = 3
-    } else if ([3, 4, 5].indexOf(video.placement) === -1) {
-      logMessage(`video.placement value of ${video.placement} is invalid for outstream context. Setting placement to 3`)
-      video.placement = 3
+      video.placement = 4
+    }
+    if (!video.plcmt) {
+      video.plcmt = 4;
     }
   }
   if (video.playbackmethod && Number.isInteger(video.playbackmethod)) {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -643,7 +643,7 @@ describe('triplelift adapter', function () {
       expect(payload.imp[2]).to.have.property('video');
       expect(payload.imp[2]).to.have.property('banner');
       expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
+      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
       // banner and incomplete video
       expect(payload.imp[3]).to.not.have.property('video');
       expect(payload.imp[3]).to.have.property('banner');
@@ -661,16 +661,16 @@ describe('triplelift adapter', function () {
       expect(payload.imp[6]).to.have.property('video');
       expect(payload.imp[6]).to.have.property('banner');
       expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
+      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
       // outstream video only
       expect(payload.imp[7]).to.have.property('video');
       expect(payload.imp[7]).to.not.have.property('banner');
-      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
+      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
       // banner and incomplete outstream (missing size); video request is permitted so banner can still monetize
       expect(payload.imp[8]).to.have.property('video');
       expect(payload.imp[8]).to.have.property('banner');
       expect(payload.imp[8].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
+      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
     });
 
     it('should check for valid outstream placement values', function () {
@@ -698,13 +698,13 @@ describe('triplelift adapter', function () {
       expect(payload.imp[12]).to.not.have.property('banner');
       expect(payload.imp[12]).to.have.property('video');
       expect(payload.imp[12].video).to.exist.and.to.be.a('object');
-      expect(payload.imp[12].video.placement).to.equal(4);
+      expect(payload.imp[12].video.placement).to.equal(3);
       expect(payload.imp[12].video.plcmt).to.equal(4);
       // outstream video; invalid placement
       expect(payload.imp[13]).to.not.have.property('banner');
       expect(payload.imp[13]).to.have.property('video');
       expect(payload.imp[13].video).to.exist.and.to.be.a('object');
-      expect(payload.imp[13].video.placement).to.equal(6);
+      expect(payload.imp[13].video.placement).to.equal(3);
       expect(payload.imp[13].video.plcmt).to.equal(4);
     });
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -497,7 +497,7 @@ describe('triplelift adapter', function () {
               context: 'outstream',
               playerSize: [640, 480],
               placement: 5,
-              plcmt: 5
+              plcmt: 4
             }
           },
           adUnitCode: 'adunit-code-instream',
@@ -693,7 +693,7 @@ describe('triplelift adapter', function () {
       expect(payload.imp[11]).to.have.property('video');
       expect(payload.imp[11].video).to.exist.and.to.be.a('object');
       expect(payload.imp[11].video.placement).to.equal(5);
-      expect(payload.imp[11].video.plcmt).to.equal(5);
+      expect(payload.imp[11].video.plcmt).to.equal(4);
       // outstream video; undefined placement
       expect(payload.imp[12]).to.not.have.property('banner');
       expect(payload.imp[12]).to.have.property('video');

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -496,7 +496,8 @@ describe('triplelift adapter', function () {
             video: {
               context: 'outstream',
               playerSize: [640, 480],
-              placement: 5
+              placement: 5,
+              plcmt: 5
             }
           },
           adUnitCode: 'adunit-code-instream',
@@ -642,7 +643,7 @@ describe('triplelift adapter', function () {
       expect(payload.imp[2]).to.have.property('video');
       expect(payload.imp[2]).to.have.property('banner');
       expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
+      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
       // banner and incomplete video
       expect(payload.imp[3]).to.not.have.property('video');
       expect(payload.imp[3]).to.have.property('banner');
@@ -660,16 +661,16 @@ describe('triplelift adapter', function () {
       expect(payload.imp[6]).to.have.property('video');
       expect(payload.imp[6]).to.have.property('banner');
       expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
+      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
       // outstream video only
       expect(payload.imp[7]).to.have.property('video');
       expect(payload.imp[7]).to.not.have.property('banner');
-      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
+      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
       // banner and incomplete outstream (missing size); video request is permitted so banner can still monetize
       expect(payload.imp[8]).to.have.property('video');
       expect(payload.imp[8]).to.have.property('banner');
       expect(payload.imp[8].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 3});
+      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 4, 'plcmt': 4});
     });
 
     it('should check for valid outstream placement values', function () {
@@ -680,26 +681,31 @@ describe('triplelift adapter', function () {
       expect(payload.imp[9]).to.have.property('video');
       expect(payload.imp[9].video).to.exist.and.to.be.a('object');
       expect(payload.imp[9].video.placement).to.equal(3);
+      expect(payload.imp[9].video.plcmt).to.equal(4);
       // outstream video; valid placement
       expect(payload.imp[10]).to.not.have.property('banner');
       expect(payload.imp[10]).to.have.property('video');
       expect(payload.imp[10].video).to.exist.and.to.be.a('object');
       expect(payload.imp[10].video.placement).to.equal(4);
+      expect(payload.imp[10].video.plcmt).to.equal(4);
       // outstream video; valid placement
       expect(payload.imp[11]).to.not.have.property('banner');
       expect(payload.imp[11]).to.have.property('video');
       expect(payload.imp[11].video).to.exist.and.to.be.a('object');
       expect(payload.imp[11].video.placement).to.equal(5);
+      expect(payload.imp[11].video.plcmt).to.equal(5);
       // outstream video; undefined placement
       expect(payload.imp[12]).to.not.have.property('banner');
       expect(payload.imp[12]).to.have.property('video');
       expect(payload.imp[12].video).to.exist.and.to.be.a('object');
-      expect(payload.imp[12].video.placement).to.equal(3);
+      expect(payload.imp[12].video.placement).to.equal(4);
+      expect(payload.imp[12].video.plcmt).to.equal(4);
       // outstream video; invalid placement
       expect(payload.imp[13]).to.not.have.property('banner');
       expect(payload.imp[13]).to.have.property('video');
       expect(payload.imp[13].video).to.exist.and.to.be.a('object');
-      expect(payload.imp[13].video.placement).to.equal(3);
+      expect(payload.imp[13].video.placement).to.equal(6);
+      expect(payload.imp[13].video.plcmt).to.equal(4);
     });
 
     it('should add tid to imp.ext if transactionId exists', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Ticket: https://triplelift.atlassian.net/browse/MPY-161

Adding support for `video.plcmt` and restructuring legacy `video.placement` logic.

