### PR TITLE
MPY-161: Adding support for video.plcmt - Update

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -241,9 +241,6 @@ function _getORTBVideo(bidRequest) {
     if (!video.placement) {
       video.placement = 1;
     }
-    if (!video.plcmt) {
-      video.plcmt = 1;
-    }
   }
   if (video.context === 'outstream') {
     if (!video.placement) {
@@ -251,9 +248,6 @@ function _getORTBVideo(bidRequest) {
     } else if ([3, 4, 5].indexOf(video.placement) === -1) {
       logMessage(`video.placement value of ${video.placement} is invalid for outstream context. Setting placement to 3`)
       video.placement = 3
-    }
-    if (!video.plcmt) {
-      video.plcmt = 4;
     }
   }
   if (video.playbackmethod && Number.isInteger(video.playbackmethod)) {

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -496,8 +496,7 @@ describe('triplelift adapter', function () {
             video: {
               context: 'outstream',
               playerSize: [640, 480],
-              placement: 5,
-              plcmt: 4
+              placement: 5
             }
           },
           adUnitCode: 'adunit-code-instream',
@@ -643,7 +642,7 @@ describe('triplelift adapter', function () {
       expect(payload.imp[2]).to.have.property('video');
       expect(payload.imp[2]).to.have.property('banner');
       expect(payload.imp[2].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
+      expect(payload.imp[2].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
       // banner and incomplete video
       expect(payload.imp[3]).to.not.have.property('video');
       expect(payload.imp[3]).to.have.property('banner');
@@ -661,16 +660,16 @@ describe('triplelift adapter', function () {
       expect(payload.imp[6]).to.have.property('video');
       expect(payload.imp[6]).to.have.property('banner');
       expect(payload.imp[6].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
+      expect(payload.imp[6].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
       // outstream video only
       expect(payload.imp[7]).to.have.property('video');
       expect(payload.imp[7]).to.not.have.property('banner');
-      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
+      expect(payload.imp[7].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'w': 640, 'h': 480, 'context': 'outstream', 'placement': 3});
       // banner and incomplete outstream (missing size); video request is permitted so banner can still monetize
       expect(payload.imp[8]).to.have.property('video');
       expect(payload.imp[8]).to.have.property('banner');
       expect(payload.imp[8].banner.format).to.deep.equal([{w: 300, h: 250}, {w: 300, h: 600}]);
-      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 3, 'plcmt': 4});
+      expect(payload.imp[8].video).to.deep.equal({'mimes': ['video/mp4'], 'maxduration': 30, 'minduration': 6, 'context': 'outstream', 'placement': 3});
     });
 
     it('should check for valid outstream placement values', function () {
@@ -681,31 +680,26 @@ describe('triplelift adapter', function () {
       expect(payload.imp[9]).to.have.property('video');
       expect(payload.imp[9].video).to.exist.and.to.be.a('object');
       expect(payload.imp[9].video.placement).to.equal(3);
-      expect(payload.imp[9].video.plcmt).to.equal(4);
       // outstream video; valid placement
       expect(payload.imp[10]).to.not.have.property('banner');
       expect(payload.imp[10]).to.have.property('video');
       expect(payload.imp[10].video).to.exist.and.to.be.a('object');
       expect(payload.imp[10].video.placement).to.equal(4);
-      expect(payload.imp[10].video.plcmt).to.equal(4);
       // outstream video; valid placement
       expect(payload.imp[11]).to.not.have.property('banner');
       expect(payload.imp[11]).to.have.property('video');
       expect(payload.imp[11].video).to.exist.and.to.be.a('object');
       expect(payload.imp[11].video.placement).to.equal(5);
-      expect(payload.imp[11].video.plcmt).to.equal(4);
       // outstream video; undefined placement
       expect(payload.imp[12]).to.not.have.property('banner');
       expect(payload.imp[12]).to.have.property('video');
       expect(payload.imp[12].video).to.exist.and.to.be.a('object');
       expect(payload.imp[12].video.placement).to.equal(3);
-      expect(payload.imp[12].video.plcmt).to.equal(4);
       // outstream video; invalid placement
       expect(payload.imp[13]).to.not.have.property('banner');
       expect(payload.imp[13]).to.have.property('video');
       expect(payload.imp[13].video).to.exist.and.to.be.a('object');
       expect(payload.imp[13].video.placement).to.equal(3);
-      expect(payload.imp[13].video.plcmt).to.equal(4);
     });
 
     it('should add tid to imp.ext if transactionId exists', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Adding support for `video.plcmt` if not set by the publisher. 
- Restructuring outstream `video.placement` values