### PR TITLE
COR-2770: Offline TLX Integration tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -350,23 +350,20 @@ const test = testTaskMaker();
 function e2eTestTaskMaker() {
   return function test(done) {
     const integ = startIntegServer();
-    const tlx = startTLXServer();
     startLocalServer();
     
     // Give TLX time to start
     setTimeout(() => {
       runWebdriver({})
         .then(() => {
-          // kill fake server and TLX
+          // kill fake server
           integ.kill('SIGINT');
-          tlx.kill('SIGINT');
           done();
           process.exit(0);
         })
         .catch(err => {
-          // kill fake server and TLX
+          // kill fake server
           integ.kill('SIGINT');
-          tlx.kill('SIGINT');
           done(new Error(`Tests failed with error: ${err}`));
           process.exit(1);
         });
@@ -465,28 +462,14 @@ function startIntegServer(dev = false, useLocalTlx = false) {
   return srv;
 }
 
-function startTLXServer() {
-  const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
-  const TLX_PORT = 8076;
-  const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+function buildBundleDevWithDirectTLX(done) {
+  // Set environment variable to use direct TLX endpoint
+  process.env.USE_DIRECT_TLX = 'true';
   
-  const args = [
-    `exchange-service:bootRun`,
-    `--args=--server.port=${TLX_PORT}`
-  ];
-  
-  const tlxSrv = spawn(gradlew, args, {
-    cwd: TLX_REPO_PATH,
-    stdio: 'inherit',
-    shell: true
-  });
-  
-  tlxSrv.on('error', (err) => {
-    console.error(`Failed to start TLX server: ${err}`);
-  });
-  
-  return tlxSrv;
+  // Create a task that builds with the environment variable set
+  return gulp.series(precompile({dev: true}), 'build-bundle-dev-no-precomp')(done);
 }
+buildBundleDevWithDirectTLX.displayName = 'build-bundle-dev-with-direct-tlx';
 
 function startDockerizedTLX() {
   const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
@@ -596,7 +579,7 @@ gulp.task('serve-prod', gulp.series(clean, gulp.parallel('build-bundle-prod', st
 gulp.task('serve-and-test', gulp.series(clean, precompile({dev: true}), gulp.parallel('build-bundle-dev-no-precomp', watchFast, testTaskMaker({watch: true}))));
 gulp.task('serve-e2e', gulp.series(clean, 'build-bundle-prod', gulp.parallel(() => startIntegServer(), startLocalServer)));
 gulp.task('serve-e2e-dev', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true), startLocalServer)));
-gulp.task('serve-e2e-tlx-offline', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true, true), startLocalServer)));
+gulp.task('serve-e2e-tlx-offline', gulp.series(clean, buildBundleDevWithDirectTLX, gulp.parallel(() => startDockerizedTLX(), startLocalServer)));
 
 gulp.task('default', gulp.series('build'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -453,7 +453,7 @@ function startIntegServer(dev = false, useLocalTlx = false) {
     args.push('--dev=true')
   }
   const env = Object.assign({}, process.env, {
-    USE_LOCAL_TLX: !!useLocalTlx
+    USE_DIRECT_TLX: !!useLocalTlx
   });
   const srv = spawn('node', args, { env });
   srv.stdout.on('data', (data) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -476,6 +476,29 @@ function startDockerizedTLX() {
   tlxDocker.on('error', (err) => {
     console.error(`Failed to start dockerized TLX: ${err}`);
   });
+
+  // Handle termination and cleanup
+  const cleanup = () => {
+    console.log('\nCleaning up dockerized TLX environment...');
+    const tlxDown = spawn(gradlew, [':dockerized:down'], {
+      cwd: TLX_REPO_PATH,
+      stdio: 'inherit',
+      shell: true
+    });
+    
+    tlxDown.on('close', () => {
+      console.log('Dockerized TLX environment shut down.');
+      process.exit(0);
+    });
+    
+    tlxDown.on('error', (err) => {
+      console.error(`Failed to clean up dockerized TLX: ${err}`);
+      process.exit(1);
+    });
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
   
   return tlxDocker;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -355,22 +355,19 @@ function e2eTestTaskMaker() {
     const integ = startIntegServer();
     startLocalServer();
     
-    // Give TLX time to start
-    setTimeout(() => {
-      runWebdriver({})
-        .then(() => {
-          // kill fake server
-          integ.kill('SIGINT');
-          done();
-          process.exit(0);
-        })
-        .catch(err => {
-          // kill fake server
-          integ.kill('SIGINT');
-          done(new Error(`Tests failed with error: ${err}`));
-          process.exit(1);
-        });
-    }, 5000);
+    runWebdriver({})
+      .then(() => {
+        // kill fake server
+        integ.kill('SIGINT');
+        done();
+        process.exit(0);
+      })
+      .catch(err => {
+        // kill fake server
+        integ.kill('SIGINT');
+        done(new Error(`Tests failed with error: ${err}`));
+        process.exit(1);
+      });
   }
 }
 
@@ -466,51 +463,64 @@ function startIntegServer(dev = false, useLocalTlx = false) {
 }
 
 function startDockerizedTLX() {
-  console.log('Starting dockerized TLX environment...');
-  const tlxDocker = spawn(gradlew, [':dockerized:up'], {
+  console.log('Bringing down any existing dockerized TLX environment...');
+  const tlxDown = spawn(gradlew, [':dockerized:down'], {
     cwd: SHARED_REPO_PATH,
     stdio: 'inherit',
     shell: true
   });
-  
-  tlxDocker.on('error', (err) => {
-    console.error(`Failed to start dockerized TLX: ${err}`);
+
+  tlxDown.on('error', (err) => {
+    console.error(`Failed to bring down dockerized TLX: ${err}`);
   });
 
-  tlxDocker.on('close', (code) => {
-    if (code !== 0) {
-      console.error(`Dockerized TLX exited with code ${code}, skipping GenerateCreative.`);
-      return;
-    }
-    runGenerateCreative((err) => {
-      if (err) console.error(`GenerateCreative failed: ${err}`);
-    });
-  });
-
-  // Handle termination and cleanup
-  const cleanup = () => {
-    console.log('\nCleaning up dockerized TLX environment...');
-    const tlxDown = spawn(gradlew, [':dockerized:down'], {
+  tlxDown.on('close', () => {
+    console.log('Starting dockerized TLX environment...');
+    const tlxDocker = spawn(gradlew, [':dockerized:up'], {
       cwd: SHARED_REPO_PATH,
       stdio: 'inherit',
       shell: true
     });
-    
-    tlxDown.on('close', () => {
-      console.log('Dockerized TLX environment shut down.');
-      process.exit(0);
-    });
-    
-    tlxDown.on('error', (err) => {
-      console.error(`Failed to clean up dockerized TLX: ${err}`);
-      process.exit(1);
-    });
-  };
 
-  process.on('SIGINT', cleanup);
-  process.on('SIGTERM', cleanup);
-  
-  return tlxDocker;
+    tlxDocker.on('error', (err) => {
+      console.error(`Failed to start dockerized TLX: ${err}`);
+    });
+
+    tlxDocker.on('close', (code) => {
+      if (code !== 0) {
+        console.error(`Dockerized TLX exited with code ${code}, skipping GenerateCreative.`);
+        return;
+      }
+      runGenerateCreative((err) => {
+        if (err) console.error(`GenerateCreative failed: ${err}`);
+      });
+    });
+
+    // Handle termination and cleanup
+    const cleanup = () => {
+      console.log('\nCleaning up dockerized TLX environment...');
+      const tlxCleanup = spawn(gradlew, [':dockerized:down'], {
+        cwd: SHARED_REPO_PATH,
+        stdio: 'inherit',
+        shell: true
+      });
+
+      tlxCleanup.on('close', () => {
+        console.log('Dockerized TLX environment shut down.');
+        process.exit(0);
+      });
+
+      tlxCleanup.on('error', (err) => {
+        console.error(`Failed to clean up dockerized TLX: ${err}`);
+        process.exit(1);
+      });
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+
+    return tlxDocker;
+  });
 }
 
 function runGenerateCreative(done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -368,7 +368,7 @@ function e2eTestTlxOfflineTaskMaker() {
           done(new Error(`Tests failed with error: ${err}`));
           process.exit(1);
         });
-    }, 60000);
+    }, 90000);
   }
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,7 +354,6 @@ function e2eTestTaskMaker() {
   return function test(done) {
     const integ = startIntegServer();
     startLocalServer();
-    
     runWebdriver({})
       .then(() => {
         // kill fake server

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,6 +38,9 @@ const {precompile} = require('./gulp.precompilation.js');
 
 const TEST_CHUNKS = 8;
 
+const SHARED_REPO_PATH = process.env.SHARED_REPO_PATH;
+const gradlew = './gradlew';
+
 // these modules must be explicitly listed in --modules to be included in the build, won't be part of "all" modules
 var explicitModules = [
   'pre1api'
@@ -463,9 +466,6 @@ function startIntegServer(dev = false, useLocalTlx = false) {
 }
 
 function startDockerizedTLX() {
-  const SHARED_REPO_PATH = process.env.SHARED_REPO_PATH;
-  const gradlew = './gradlew';
-  
   console.log('Starting dockerized TLX environment...');
   const tlxDocker = spawn(gradlew, [':dockerized:up'], {
     cwd: SHARED_REPO_PATH,
@@ -475,6 +475,16 @@ function startDockerizedTLX() {
   
   tlxDocker.on('error', (err) => {
     console.error(`Failed to start dockerized TLX: ${err}`);
+  });
+
+  tlxDocker.on('close', (code) => {
+    if (code !== 0) {
+      console.error(`Dockerized TLX exited with code ${code}, skipping GenerateCreative.`);
+      return;
+    }
+    runGenerateCreative((err) => {
+      if (err) console.error(`GenerateCreative failed: ${err}`);
+    });
   });
 
   // Handle termination and cleanup
@@ -501,6 +511,29 @@ function startDockerizedTLX() {
   process.on('SIGTERM', cleanup);
   
   return tlxDocker;
+}
+
+function runGenerateCreative(done) {
+  console.log('Running GenerateCreative...');
+  const generateCreative = spawn(gradlew, [':dockerized:run'], {
+    cwd: SHARED_REPO_PATH,
+    stdio: 'inherit',
+    shell: true
+  });
+
+  generateCreative.on('error', (err) => {
+    console.error(`Failed to run GenerateCreative: ${err}`);
+    done(err);
+  });
+
+  generateCreative.on('close', (code) => {
+    if (code !== 0) {
+      done(new Error(`GenerateCreative exited with code ${code}`));
+    } else {
+      console.log('GenerateCreative completed successfully.');
+      done();
+    }
+  });
 }
 
 function startLocalServer(options = {}) {
@@ -593,7 +626,7 @@ gulp.task('serve-prod', gulp.series(clean, gulp.parallel('build-bundle-prod', st
 gulp.task('serve-and-test', gulp.series(clean, precompile({dev: true}), gulp.parallel('build-bundle-dev-no-precomp', watchFast, testTaskMaker({watch: true}))));
 gulp.task('serve-e2e', gulp.series(clean, 'build-bundle-prod', gulp.parallel(() => startIntegServer(), startLocalServer)));
 gulp.task('serve-e2e-dev', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true), startLocalServer)));
-gulp.task('serve-e2e-tlx-offline', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startDockerizedTLX(), () => startIntegServer(true, true), startLocalServer)));
+gulp.task('serve-e2e-tlx-offline', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startDockerizedTLX(), () => startIntegServer(true, true), () => runGenerateCreative, startLocalServer)));
 
 gulp.task('default', gulp.series('build'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -350,6 +350,7 @@ const test = testTaskMaker();
 function e2eTestTaskMaker() {
   return function test(done) {
     const integ = startIntegServer();
+    const tlx = startTLXServer();
     startLocalServer();
     
     // Give TLX time to start
@@ -446,13 +447,13 @@ function buildPostbid() {
     .pipe(gulp.dest('build/postbid/'));
 }
 
-function startIntegServer(dev = false) {
+function startIntegServer(dev = false, useLocalTlx = false) {
   const args = ['./test/fake-server/index.js', `--port=${INTEG_SERVER_PORT}`, `--host=${INTEG_SERVER_HOST}`];
   if (dev) {
     args.push('--dev=true')
   }
   const env = Object.assign({}, process.env, {
-    USE_LOCAL_TLX: 'true'
+    USE_LOCAL_TLX: !!useLocalTlx
   });
   const srv = spawn('node', args, { env });
   srv.stdout.on('data', (data) => {
@@ -485,6 +486,24 @@ function startTLXServer() {
   });
   
   return tlxSrv;
+}
+
+function startDockerizedTLX() {
+  const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
+  const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+  
+  console.log('Starting dockerized TLX environment...');
+  const tlxDocker = spawn(gradlew, [':dockerized:up'], {
+    cwd: TLX_REPO_PATH,
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  tlxDocker.on('error', (err) => {
+    console.error(`Failed to start dockerized TLX: ${err}`);
+  });
+  
+  return tlxDocker;
 }
 
 function startLocalServer(options = {}) {
@@ -577,6 +596,7 @@ gulp.task('serve-prod', gulp.series(clean, gulp.parallel('build-bundle-prod', st
 gulp.task('serve-and-test', gulp.series(clean, precompile({dev: true}), gulp.parallel('build-bundle-dev-no-precomp', watchFast, testTaskMaker({watch: true}))));
 gulp.task('serve-e2e', gulp.series(clean, 'build-bundle-prod', gulp.parallel(() => startIntegServer(), startLocalServer)));
 gulp.task('serve-e2e-dev', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true), startLocalServer)));
+gulp.task('serve-e2e-tlx-offline', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true, true), startLocalServer)));
 
 gulp.task('default', gulp.series('build'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -462,15 +462,6 @@ function startIntegServer(dev = false, useLocalTlx = false) {
   return srv;
 }
 
-function buildBundleDevWithDirectTLX(done) {
-  // Set environment variable to use direct TLX endpoint
-  process.env.USE_DIRECT_TLX = 'true';
-  
-  // Create a task that builds with the environment variable set
-  return gulp.series(precompile({dev: true}), 'build-bundle-dev-no-precomp')(done);
-}
-buildBundleDevWithDirectTLX.displayName = 'build-bundle-dev-with-direct-tlx';
-
 function startDockerizedTLX() {
   const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
   const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
@@ -579,7 +570,7 @@ gulp.task('serve-prod', gulp.series(clean, gulp.parallel('build-bundle-prod', st
 gulp.task('serve-and-test', gulp.series(clean, precompile({dev: true}), gulp.parallel('build-bundle-dev-no-precomp', watchFast, testTaskMaker({watch: true}))));
 gulp.task('serve-e2e', gulp.series(clean, 'build-bundle-prod', gulp.parallel(() => startIntegServer(), startLocalServer)));
 gulp.task('serve-e2e-dev', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startIntegServer(true), startLocalServer)));
-gulp.task('serve-e2e-tlx-offline', gulp.series(clean, buildBundleDevWithDirectTLX, gulp.parallel(() => startDockerizedTLX(), startLocalServer)));
+gulp.task('serve-e2e-tlx-offline', gulp.series(clean, 'build-bundle-dev', gulp.parallel(() => startDockerizedTLX(), () => startIntegServer(true, true), startLocalServer)));
 
 gulp.task('default', gulp.series('build'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -463,12 +463,12 @@ function startIntegServer(dev = false, useLocalTlx = false) {
 }
 
 function startDockerizedTLX() {
-  const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
-  const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+  const SHARED_REPO_PATH = process.env.SHARED_REPO_PATH;
+  const gradlew = './gradlew';
   
   console.log('Starting dockerized TLX environment...');
   const tlxDocker = spawn(gradlew, [':dockerized:up'], {
-    cwd: TLX_REPO_PATH,
+    cwd: SHARED_REPO_PATH,
     stdio: 'inherit',
     shell: true
   });
@@ -481,7 +481,7 @@ function startDockerizedTLX() {
   const cleanup = () => {
     console.log('\nCleaning up dockerized TLX environment...');
     const tlxDown = spawn(gradlew, [':dockerized:down'], {
-      cwd: TLX_REPO_PATH,
+      cwd: SHARED_REPO_PATH,
       stdio: 'inherit',
       shell: true
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -351,19 +351,25 @@ function e2eTestTaskMaker() {
   return function test(done) {
     const integ = startIntegServer();
     startLocalServer();
-    runWebdriver({})
-      .then(() => {
-        // kill fake server
-        integ.kill('SIGINT');
-        done();
-        process.exit(0);
-      })
-      .catch(err => {
-        // kill fake server
-        integ.kill('SIGINT');
-        done(new Error(`Tests failed with error: ${err}`));
-        process.exit(1);
-      });
+    
+    // Give TLX time to start
+    setTimeout(() => {
+      runWebdriver({})
+        .then(() => {
+          // kill fake server and TLX
+          integ.kill('SIGINT');
+          tlx.kill('SIGINT');
+          done();
+          process.exit(0);
+        })
+        .catch(err => {
+          // kill fake server and TLX
+          integ.kill('SIGINT');
+          tlx.kill('SIGINT');
+          done(new Error(`Tests failed with error: ${err}`));
+          process.exit(1);
+        });
+    }, 5000);
   }
 }
 
@@ -445,7 +451,10 @@ function startIntegServer(dev = false) {
   if (dev) {
     args.push('--dev=true')
   }
-  const srv = spawn('node', args);
+  const env = Object.assign({}, process.env, {
+    USE_LOCAL_TLX: 'true'
+  });
+  const srv = spawn('node', args, { env });
   srv.stdout.on('data', (data) => {
     console.log(`stdout: ${data}`);
   });
@@ -453,6 +462,29 @@ function startIntegServer(dev = false) {
     console.log(`stderr: ${data}`);
   });
   return srv;
+}
+
+function startTLXServer() {
+  const TLX_REPO_PATH = process.env.TLX_REPO_PATH || '/Users/carlos_cobaleda/development/eclipse-2025.12-workspace/shared';
+  const TLX_PORT = 8076;
+  const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+  
+  const args = [
+    `exchange-service:bootRun`,
+    `--args=--server.port=${TLX_PORT}`
+  ];
+  
+  const tlxSrv = spawn(gradlew, args, {
+    cwd: TLX_REPO_PATH,
+    stdio: 'inherit',
+    shell: true
+  });
+  
+  tlxSrv.on('error', (err) => {
+    console.error(`Failed to start TLX server: ${err}`);
+  });
+  
+  return tlxSrv;
 }
 
 function startLocalServer(options = {}) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -350,6 +350,28 @@ function testTaskMaker(options = {}) {
 
 const test = testTaskMaker();
 
+function e2eTestTlxOfflineTaskMaker() {
+  return function test(done) {
+    startDockerizedTLX();
+    const integ = startIntegServer(true, true);
+    startLocalServer();
+    setTimeout(() => {
+      console.log('Running e2e tests for TLX offline exchange...');
+      runWebdriver({ file: 'test/spec/e2e/triplelift_offline_exchange/offline_exchange.spec.js', timeout: 60000 })
+        .then(() => {
+          integ.kill('SIGINT');
+          done();
+          process.exit(0);
+        })
+        .catch(err => {
+          integ.kill('SIGINT');
+          done(new Error(`Tests failed with error: ${err}`));
+          process.exit(1);
+        });
+    }, 60000);
+  }
+}
+
 function e2eTestTaskMaker() {
   return function test(done) {
     const integ = startIntegServer();
@@ -642,6 +664,7 @@ gulp.task('default', gulp.series('build'));
 gulp.task('e2e-test-only', gulp.series(requireNodeVersion(16), () => runWebdriver({file: argv.file})));
 gulp.task('e2e-test', gulp.series(requireNodeVersion(16), clean, 'build-bundle-prod', e2eTestTaskMaker()));
 gulp.task('e2e-test-nobuild', gulp.series(requireNodeVersion(16), e2eTestTaskMaker()));
+gulp.task('e2e-test-tlx-offline', gulp.series(requireNodeVersion(16), clean, 'build-bundle-dev', e2eTestTlxOfflineTaskMaker()));
 
 // other tasks
 gulp.task(bundleToStdout);

--- a/test/fake-server/bundle.js
+++ b/test/fake-server/bundle.js
@@ -4,9 +4,14 @@ const host = argv.host || 'localhost';
 const port = argv.port || 4444;
 const dev = argv.dev || false;
 
+// Use direct TLX endpoint if USE_DIRECT_TLX is set, otherwise use fake-server
+const tlxEndpoint = process.env.USE_DIRECT_TLX === 'true'
+  ? 'http://localhost:8076/header/auction'
+  : `http://${host}:${port}/triplelift`;
+
 const REPLACE = {
   'https://ib.adnxs.com/ut/v3/prebid': `http://${host}:${port}/appnexus`,
-  'https://tlx.3lift.com/header/auction': `http://localhost:8076/header/auction`,
+  'https://tlx.3lift.com/header/auction': tlxEndpoint,
 };
 
 const replaceStrings = (() => {

--- a/test/fake-server/bundle.js
+++ b/test/fake-server/bundle.js
@@ -6,7 +6,7 @@ const dev = argv.dev || false;
 
 const REPLACE = {
   'https://ib.adnxs.com/ut/v3/prebid': `http://${host}:${port}/appnexus`,
-  'https://tlx.3lift.com/header/auction': `http://${host}:${port}/triplelift`,
+  'https://tlx.3lift.com/header/auction': `http://localhost:8076/header/auction`,
 };
 
 const replaceStrings = (() => {

--- a/test/fake-server/fixtures/triplelift/banner/request.json
+++ b/test/fake-server/fixtures/triplelift/banner/request.json
@@ -6,40 +6,12 @@
       "imp": [
         {
           "id": 0,
-          "tagid": "test_inventory_code",
+          "tagid": "makersalley_pixel",
           "banner": {
             "format": [
               {
-                "w": 300,
-                "h": 250
-              },
-              {
-                "w": 300,
-                "h": 600
-              }
-            ]
-          },
-          "fpd": {
-            "context": {
-              "tidSource": "pbjs"
-            }
-          },
-          "ext": {
-            "tidSource": "pbjs"
-          }
-        },
-        {
-          "id": 1,
-          "tagid": "test_inventory_code",
-          "banner": {
-            "format": [
-              {
-                "w": 300,
-                "h": 250
-              },
-              {
-                "w": 300,
-                "h": 600
+                  "w": 432,
+                  "h": 243
               }
             ]
           },
@@ -52,85 +24,7 @@
             "tidSource": "pbjs"
           }
         }
-      ],
-      "ext": {
-        "fpd": {
-          "context": {
-            "domain": "localhost:9999",
-            "publisher": {
-              "domain": "localhost:9999"
-            },
-            "page": "http://localhost:9999/test/pages/triplelift_banner.html?pbjs_debug=true",
-            "ext": {
-              "data": {
-                "documentLang": "en"
-              }
-            },
-            "content": {
-              "language": "en"
-            }
-          }
-        },
-        "ortb2": {
-          "site": {
-            "domain": "localhost:9999",
-            "publisher": {
-              "domain": "localhost:9999"
-            },
-            "page": "http://localhost:9999/test/pages/triplelift_banner.html?pbjs_debug=true",
-            "ext": {
-              "data": {
-                "documentLang": "en"
-              }
-            },
-            "content": {
-              "language": "en"
-            }
-          },
-          "device": {
-            "w": 5120,
-            "h": 1440,
-            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
-            "language": "en",
-            "ext": {
-              "vpw": 1416,
-              "vph": 1353
-            },
-            "sua": {
-              "source": 1,
-              "platform": {
-                "brand": "macOS"
-              },
-              "browsers": [
-                {
-                  "brand": "Google Chrome",
-                  "version": [
-                    "149"
-                  ]
-                },
-                {
-                  "brand": "Chromium",
-                  "version": [
-                    "149"
-                  ]
-                },
-                {
-                  "brand": "Not)A;Brand",
-                  "version": [
-                    "24"
-                  ]
-                }
-              ],
-              "mobile": 0
-            }
-          },
-          "source": {
-            "ext": {
-              "tidSource": "pbjs"
-            }
-          }
-        }
-      }
+      ]
     }
   }
 }

--- a/test/pages/triplelift_banner.html
+++ b/test/pages/triplelift_banner.html
@@ -16,86 +16,71 @@
 		var pbjs = pbjs || {};
 		pbjs.que = pbjs.que || [];
 
-		// Prebid Banner Ad Unit
 		const adUnits = [{
 			code: 'div-gpt-ad-1460505748561-0',
 			mediaTypes: {
 				banner: {
-					sizes: [[300, 250], [300, 600]],
+					sizes: [[432, 243]],
 				}
 			},
 			bids: [{
 				bidder: 'triplelift',
 				params: {
 					placementId: 13144370,
-          inventoryCode: "test_inventory_code",
-          sharedPublisherId: "1234"
+					inventoryCode: 'makersalley_pixel',
+					sharedPublisherId: '1234'
 				}
 			}]
-		 }
-		,{
-			code: 'div-gpt-ad-1460505748561-1',
-			mediaTypes: {
-				banner: {
-					sizes: [[300, 250], [300, 600]],
-				}
-			},
-			bids: [{
-				bidder: "triplelift",
-				params: {
-					placementId: 13144370,
-          inventoryCode: "test_inventory_code",
-          sharedPublisherId: "1234"
-				}
-			}]
-		}
-	];
-	</script>
+		}];
+    </script>
 
-	<script>
-		var googletag = googletag || {};
-		googletag.cmd = googletag.cmd || [];
+    <script>
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
 
-		googletag.cmd.push(function() {
-			googletag.pubads().disableInitialLoad();
-		});
+      googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+      });
 
-		pbjs.que.push(function () {
-			pbjs.setConfig({enableTIDs: true});
-			pbjs.addAdUnits(adUnits);
-			pbjs.requestBids({ bidsBackHandler: sendAdServerRequest });
-		});
 
-		function sendAdServerRequest() {
-			googletag.cmd.push(function () {
-				pbjs.que.push(function () {
-					pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
-					googletag.pubads().refresh();
-				});
-			});
-		}
-	</script>
+      pbjs.que.push(function () {
+        pbjs.setConfig({
+          enableTIDs: true,
+          pageUrl: 'https://www.hipfoodiemom.com/test'
+        });
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({ bidsBackHandler: sendAdServerRequest });
+      });
 
-	<script>
-		googletag.cmd.push(function () {
-			googletag
-				.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0')
-				.addService(googletag.pubads());
+      function sendAdServerRequest() {
+        googletag.cmd.push(function () {
+          pbjs.que.push(function () {
+            pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
+            googletag.pubads().refresh();
+          });
+        });
+      }
+    </script>
 
-			googletag.pubads().enableSingleRequest();
-			googletag.enableServices();
-		});
-	</script>
+    <script>
+        googletag.cmd.push(function () {
+          googletag
+            .defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0')
+            .addService(googletag.pubads());
+          googletag.pubads().enableSingleRequest();
+          googletag.enableServices();
+        });
+      </script>
+    </head>
+    <h2>Prebid.js Banner Ad Unit Test</h2>
+    <div id='div-gpt-ad-1460505748561-0'>
+      <script>
+        googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
+      </script>
+    </div>
+    <div id="targeting-keys"></div>
+
+    <body>
 </head>
-
-<body>
-	<h2>Prebid.js Banner Ad Unit Test</h2>
-	<div id='div-gpt-ad-1460505748561-0'>
-		<script>
-			googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
-		</script>
-	</div>
-	<div id="targeting-keys"></div>
-</body>
 
 </html>

--- a/test/spec/e2e/triplelift_offline_exchange/offline_exchange.spec.js
+++ b/test/spec/e2e/triplelift_offline_exchange/offline_exchange.spec.js
@@ -1,25 +1,28 @@
 const expect = require('chai').expect;
-const { setupTest, testPageURL, switchFrames } = require('../../../helpers/testing-utils.js');
+const { setupTest, testPageURL, switchFrames, loadAndWaitForElement } = require('../../../helpers/testing-utils.js');
 
 const TEST_PAGE_URL = testPageURL('triplelift_banner.html?pbjs_debug=true');
 const CREATIVE_IFRAME_CSS_SELECTOR = 'iframe[id="google_ads_iframe_/19968336/header-bid-tag-0_0"]';
-const TL_IFRAME_CSS_SELECTOR = 'iframe[class*="tl-iframe"]';
 
 describe('TLX Offline Warmup', function () {
+  this.timeout(300000);
   before(async function () {
-    for (let i = 0; i < 3; i++) {
-      await browser.url(TEST_PAGE_URL);
+    for (let i = 0; i < 5; i++) {
+      await loadAndWaitForElement(TEST_PAGE_URL, CREATIVE_IFRAME_CSS_SELECTOR);
+      await browser.pause(2000);
     }
   });
-});
 
-// setupTest({
-//   url: TEST_PAGE_URL,
-//   waitFor: CREATIVE_IFRAME_CSS_SELECTOR,
-// }, `Prebid.js Banner Ad Unit Test (loading ${TEST_PAGE_URL})`, function () {
-//   it('should render an image from img.3lift.com', async function () {
-//     await switchFrames(CREATIVE_IFRAME_CSS_SELECTOR, 'iframe', TL_IFRAME_CSS_SELECTOR);
-//     const existingImage = await $('img[src*="img.3lift.com"]').isExisting();
-//     expect(existingImage).to.be.true;
-//   });
-// });
+  setupTest({
+    url: TEST_PAGE_URL,
+    waitFor: CREATIVE_IFRAME_CSS_SELECTOR,
+  }, `Prebid.js Banner Ad Unit Test (loading ${TEST_PAGE_URL})`, function () {
+    it('should render an image from img.3lift.com', async function () {
+      await switchFrames(CREATIVE_IFRAME_CSS_SELECTOR, 'iframe');
+      const tlodDiv = await $('div.tlod').isExisting();
+      expect(tlodDiv).to.be.true;
+      const existingImage = await $('img[src*="img.3lift.com"]').isExisting();
+      expect(existingImage).to.be.true;
+    });
+  });
+});

--- a/test/spec/e2e/triplelift_offline_exchange/offline_exchange.spec.js
+++ b/test/spec/e2e/triplelift_offline_exchange/offline_exchange.spec.js
@@ -1,0 +1,25 @@
+const expect = require('chai').expect;
+const { setupTest, testPageURL, switchFrames } = require('../../../helpers/testing-utils.js');
+
+const TEST_PAGE_URL = testPageURL('triplelift_banner.html?pbjs_debug=true');
+const CREATIVE_IFRAME_CSS_SELECTOR = 'iframe[id="google_ads_iframe_/19968336/header-bid-tag-0_0"]';
+const TL_IFRAME_CSS_SELECTOR = 'iframe[class*="tl-iframe"]';
+
+describe('TLX Offline Warmup', function () {
+  before(async function () {
+    for (let i = 0; i < 3; i++) {
+      await browser.url(TEST_PAGE_URL);
+    }
+  });
+});
+
+// setupTest({
+//   url: TEST_PAGE_URL,
+//   waitFor: CREATIVE_IFRAME_CSS_SELECTOR,
+// }, `Prebid.js Banner Ad Unit Test (loading ${TEST_PAGE_URL})`, function () {
+//   it('should render an image from img.3lift.com', async function () {
+//     await switchFrames(CREATIVE_IFRAME_CSS_SELECTOR, 'iframe', TL_IFRAME_CSS_SELECTOR);
+//     const existingImage = await $('img[src*="img.3lift.com"]').isExisting();
+//     expect(existingImage).to.be.true;
+//   });
+// });

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -7,7 +7,11 @@ exports.config = {
     {
       browserName: 'chrome',
       'goog:chromeOptions': {
-        args: ['headless', 'disable-gpu'],
+        args: [
+          'headless',
+          'disable-gpu',
+          '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        ],
       },
     },
     {

--- a/wdio.shared.conf.js
+++ b/wdio.shared.conf.js
@@ -19,7 +19,7 @@ exports.config = {
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000,
+    timeout: 300000,
     compilers: ['js:@babel/register'],
   },
   // if you see error, update this to spec reporter and logLevel above to get detailed report.


### PR DESCRIPTION
### Summary

Now we use the offline exchange during the e2e tests. We can use:
- `prebid_js; nvm use; gulp serve-e2e-tlx-offline;`: Run PrebidJS locally using the local exchange.
- `prebid_js; nvm use; gulp e2e-test-tlx-offline --local;` Run E2E tests locally using the local exchange.

You have to define the variable:
```
export SHARED_REPO_PATH=[YOUR_SHARED_REPO_LOCATION]
```

### Dependencies
- https://github.com/triplelift-internal/shared/pull/15819

### Test Plan
- Run `prebid_js; nvm use; gulp serve-e2e-tlx-offline;`. This will bring up the exchange in offline mode.
  - Go to  http://localhost:9999/test/pages/triplelift_banner.html?pbjs_debug=true
  - You should see a render that uses offline tlx creative
<img width="2672" height="1552" alt="image" src="https://github.com/user-attachments/assets/06913999-acbb-4a02-81d1-f07b5587fa1d" />
- Run  `prebid_js; nvm use; gulp e2e-test-tlx-offline --local;`
  - Tests should pass correctly
<img width="1073" height="658" alt="image" src="https://github.com/user-attachments/assets/9e677f2d-ae1d-4565-af22-c59268ca8def" />
